### PR TITLE
Switch shapes to ref counts

### DIFF
--- a/src/physics/jolt/back/operators/cleaner.mjs
+++ b/src/physics/jolt/back/operators/cleaner.mjs
@@ -164,7 +164,7 @@ class Cleaner {
             return false;
         }
 
-        Jolt.destroy(shape);
+        shape.Release();
 
         tracker.shapeMap.delete(shapeNumber);
 

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -196,6 +196,7 @@ class Creator {
             return false;
         }
         const shape = shapeResult.Get();
+        shape.AddRef();
 
         this._backend.tracker.shapeMap.set(num, shape);
 

--- a/src/physics/jolt/back/operators/querier.mjs
+++ b/src/physics/jolt/back/operators/querier.mjs
@@ -1,4 +1,9 @@
 import { Debug } from '../../debug.mjs';
+import {
+    BUFFER_READ_BOOL, BUFFER_READ_UINT32, BUFFER_READ_UINT8, BUFFER_WRITE_BOOL,
+    BUFFER_WRITE_JOLTVEC32, BUFFER_WRITE_UINT16, BUFFER_WRITE_UINT32, CMD_CAST_RAY, CMD_CAST_SHAPE,
+    COMPONENT_SYSTEM_MANAGER
+} from '../../constants.mjs';
 
 const params = [];
 

--- a/src/physics/jolt/manager.mjs
+++ b/src/physics/jolt/manager.mjs
@@ -19,6 +19,8 @@ import {
     OPERATOR_MODIFIER, OPERATOR_QUERIER
 } from './constants.mjs';
 
+const halfExtent = new Vec3(0.5, 0.5, 0.5);
+
 class JoltManager extends PhysicsManager {
     constructor(app, opts, resolve) {
         const config = {
@@ -167,10 +169,10 @@ class JoltManager extends PhysicsManager {
         const opts = {
             // defaults
             density: 1000,
-            shapePosition: new Vec3(),
-            shapeRotation: new Quat(),
-            scale: new Vec3(1, 1, 1),
-            halfExtent: new Vec3(0.5, 0.5, 0.5),
+            shapePosition: Vec3.ZERO,
+            shapeRotation: Quat.IDENTITY,
+            scale: Vec3.ONE,
+            halfExtent,
             convexRadius: 0.05,
             halfHeight: 0.5,
             radius: 0.5,


### PR DESCRIPTION
- Switch the handling of the free shapes to Jolt, instead of JS side, which could cause a crash under some conditions.
- Minor optimization: remove some vectors allocations.
- Add missing imports in Querier.