### PR TITLE
Make contactEventsEnabled private

### DIFF
--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -51,7 +51,6 @@ class JoltBackend {
             // contact events
             charContactEventsEnabled: true,
             vehicleContactEventsEnabled: false,
-            contactEventsEnabled: true,
             contactAddedEventsEnabled: true,
             contactPersistedEventsEnabled: false,
             contactRemovedEventsEnabled: true,
@@ -70,6 +69,10 @@ class JoltBackend {
             ],
             ...data.config
         };
+        
+        config.contactEventsEnabled = config.contactAddedEventsEnabled ||
+            config.contactPersistedEventsEnabled || config.contactRemovedEventsEnabled;
+
         this._config = config;
         this._dispatcher = messenger;
         this._time = 0;


### PR DESCRIPTION
Fixes: #27

Moves `contactEventsEnabled` option to private API, as it can be derived from `added`, `persisted` and `removed` events.