### PR TITLE
Add cast fraction

### DIFF
--- a/src/physics/jolt/back/operators/querier.mjs
+++ b/src/physics/jolt/back/operators/querier.mjs
@@ -13,6 +13,7 @@ function writeRayHit(cb, system, tracker, cast, calculateNormal, hit, Jolt) {
     const index = tracker.getPCID(Jolt.getPointer(body));
     cb.write(index, BUFFER_WRITE_UINT32, false);
     cb.write(point, BUFFER_WRITE_JOLTVEC32, false);
+    cb.write(hit.mFraction, BUFFER_WRITE_FLOAT32, false);
     cb.write(normal, BUFFER_WRITE_JOLTVEC32);
 }
 
@@ -30,6 +31,7 @@ function writeShapeHit(cb, system, tracker, cast, calculateNormal, hit, Jolt) {
     const index = tracker.getPCID(Jolt.getPointer(body));
     cb.write(index, BUFFER_WRITE_UINT32, false);
     cb.write(point, BUFFER_WRITE_JOLTVEC32, false);
+    cb.write(hit.mFraction, BUFFER_WRITE_FLOAT32, false);
     cb.write(normal, BUFFER_WRITE_JOLTVEC32);
 }
 

--- a/src/physics/jolt/front/response-handler.mjs
+++ b/src/physics/jolt/front/response-handler.mjs
@@ -29,10 +29,11 @@ class CharContactResult {
     }
 }
 
-class RaycastResult {
-    constructor(entity, point, normal) {
+class CastResult {
+    constructor(entity, point, fraction, normal) {
         this.entity = entity;
         this.point = point;
+        this.fraction = fraction;
         if (normal) {
             this.normal = normal;
         }
@@ -190,6 +191,8 @@ class ResponseHandler {
                 cb.read(BUFFER_READ_FLOAT32)
             );
 
+            const fraction = cb.read(BUFFER_READ_FLOAT32);
+
             let normal;
             if (cb.flag) {
                 normal = new Vec3(
@@ -206,7 +209,7 @@ class ResponseHandler {
                 continue;
             }
 
-            const r = new RaycastResult(entity, point, normal);
+            const r = new CastResult(entity, point, fraction, normal);
 
             if (firstOnly) {
                 result = r;


### PR DESCRIPTION
Fixes: #5 

Adds a ray fraction value to the cast result. The fraction is in `[0, 1]` range and tells the percentage of ray length where the hit occurred.