### PR TITLE
Allow to stop isometry auto-update

### DIFF
--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -584,8 +584,7 @@ class JoltBackend {
             }
         }
 
-        // Reset the cursors, so we can start from the buffer beginning on
-        // the next step request
+        // Reset the cursors, so we can start from the buffer beginning on the next step request
         cb.reset();
 
         return ok;
@@ -772,8 +771,11 @@ class JoltBackend {
             for (let i = 0; i < count; i++) {
                 const bodyID = bodyList.at(i);
                 const body = system.GetBodyLockInterface().TryGetBody(bodyID);
-                const pointer = Jolt.getPointer(body);
-                if (pointer === 0 || body.isCharPaired || body.GetMotionType() !== Jolt.EMotionType_Dynamic) {
+
+                if (!body.autoUpdateIsometry ||
+                        body.isCharPaired ||
+                        body.GetMotionType() !== Jolt.EMotionType_Dynamic ||
+                        Jolt.getPointer(body) === 0) {
                     continue;
                 }
 

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -330,6 +330,8 @@ class Creator {
         const body = bodyInterface.CreateBody(bodyCreationSettings);
         bodyInterface.AddBody(body.GetID(), Jolt.EActivation_Activate);
 
+        body.autoUpdateIsometry = cb.read(BUFFER_READ_BOOL);
+
         if ($_DEBUG) {
             this._addDebugDraw(cb.read(BUFFER_READ_BOOL), body);
         }

--- a/src/physics/jolt/constants.mjs
+++ b/src/physics/jolt/constants.mjs
@@ -169,6 +169,7 @@ export const CMD_COLLIDE_POINT = 37;
 export const CMD_COLLIDE_SHAPE_IDX = 38;
 
 export const CMD_SET_MOTION_QUALITY = 39;
+export const CMD_SET_AUTO_UPDATE_ISOMETRY = 40;
 
 // Constraints 500+
 

--- a/src/physics/jolt/front/body/component.mjs
+++ b/src/physics/jolt/front/body/component.mjs
@@ -9,7 +9,7 @@ import {
     CMD_SET_MOTION_TYPE, CMD_SET_OBJ_LAYER, CMD_USE_MOTION_STATE, MOTION_QUALITY_DISCRETE,
     MOTION_TYPE_DYNAMIC, MOTION_TYPE_KINEMATIC, MOTION_TYPE_STATIC, OBJ_LAYER_NON_MOVING,
     OMP_CALCULATE_MASS_AND_INERTIA, OMP_MASS_AND_INERTIA_PROVIDED, OPERATOR_CLEANER,
-    OPERATOR_MODIFIER, SHAPE_CONVEX_HULL, SHAPE_HEIGHTFIELD, SHAPE_MESH
+    OPERATOR_MODIFIER, SHAPE_CONVEX_HULL, SHAPE_HEIGHTFIELD, SHAPE_MESH, CMD_SET_AUTO_UPDATE_ISOMETRY
 } from '../../constants.mjs';
 
 const vec3 = new Vec3();
@@ -31,6 +31,8 @@ class BodyComponent extends ShapeComponent {
     _allowSleeping = true;
 
     _angularDamping = 0;
+
+    _autoUpdateIsometry = true;
 
     _collisionGroup = null;
 
@@ -198,6 +200,73 @@ class BodyComponent extends ShapeComponent {
      */
     get angularVelocity() {
         return this._angularVelocity;
+    }
+
+    /**
+     * Changes the isometry update method:
+     * - `true`: framework will synchronize entity position/rotation in visual world with a
+     * physical body in physics world automatically.
+     * - `false`: framework expects a user to do it manually.
+     *
+     * If `false` is set, then physics will no longer auto-update entity/body position/rotation.
+     * - Backend will not tell frontend where dynamic body is.
+     * - Frontend will not tell backend where kinematic body is.
+     * - This setting has no effect on a static body.
+     *
+     * This is useful, for example, when you have many kinematic objects and you rarely change
+     * their isometry. In some cases this is also useful for dynamic bodies, e.g. when their
+     * gravity factor is set to zero, and you use {@link moveKinematic} to translate it manually.
+     *
+     * @example
+     * ```js
+     * entity.addComponent('body', {
+     *     motionType: MOTION_TYPE_KINEMATIC,
+     *     objectLayer: OBJ_LAYER_MOVING,
+     *     autoUpdateIsometry: false
+     * });
+     *
+     * // then on frame update, or when needed, move both - body and entity
+     * entity.setPosition(newPosition);
+     * entity.body.teleport(newPosition);
+     * // or any of the body movement methods, e.g.
+     * // entity.body.moveKinematic(newPosition, Quat.IDENTITY, time);
+     * ```
+     */
+    set autoUpdateIsometry(bool) {
+        if ($_DEBUG) {
+            const ok = Debug.checkBool(bool, `Invalid manual isometry update state boolean`);
+            if (!ok) return;
+        }
+
+        if (this._autoUpdateIsometry === bool) {
+            return;
+        }
+
+        this._autoUpdateIsometry = bool;
+
+        const type = this._motionType;
+        if (bool && type === MOTION_TYPE_DYNAMIC || type === MOTION_TYPE_KINEMATIC) {
+            this._isometryEvent = this.system.on('write-isometry', this.writeIsometry, this);
+        } else {
+            this._isometryEvent?.off();
+            this._isometryEvent = null;
+        }
+
+        this.system.addCommand(
+            OPERATOR_MODIFIER, CMD_SET_AUTO_UPDATE_ISOMETRY, this._index,
+            bool, BUFFER_WRITE_BOOL, false
+        );
+    }
+
+    /**
+     * Returns a boolean, telling if the position and rotation of this body is updated
+     * automatically.
+     *
+     * @returns {boolean} - Boolean, telling the isometry update state.
+     * @defaultValue false
+     */
+    get autoUpdateIsometry() {
+        return this._autoUpdateIsometry;
     }
 
     /**
@@ -909,22 +978,16 @@ class BodyComponent extends ShapeComponent {
     }
 
     writeIsometry() {
-        if (this._motionType === MOTION_TYPE_DYNAMIC) {
-            return;
-        }
-
         const entity = this.entity;
 
-        if (entity._dirtyWorld) {
-            const position = entity.getPosition();
-            const rotation = entity.getRotation();
+        const position = entity.getPosition();
+        const rotation = entity.getRotation();
 
-            this.system.addCommand(
-                OPERATOR_MODIFIER, CMD_MOVE_BODY, this._index,
-                position, BUFFER_WRITE_VEC32, false,
-                rotation, BUFFER_WRITE_VEC32, false
-            );
-        }
+        this.system.addCommand(
+            OPERATOR_MODIFIER, CMD_MOVE_BODY, this._index,
+            position, BUFFER_WRITE_VEC32, false,
+            rotation, BUFFER_WRITE_VEC32, false
+        );
     }
 
     writeComponentData(cb) {
@@ -985,6 +1048,8 @@ class BodyComponent extends ShapeComponent {
             }
         }
 
+        cb.write(this._autoUpdateIsometry, BUFFER_WRITE_BOOL, false);
+
         if ($_DEBUG) {
             cb.write(this._debugDraw, BUFFER_WRITE_BOOL, false);
         }
@@ -1006,7 +1071,8 @@ class BodyComponent extends ShapeComponent {
 
         if (!isCompoundChild) {
             const motionType = this._motionType;
-            if ((motionType === MOTION_TYPE_DYNAMIC && this._trackDynamic) || motionType === MOTION_TYPE_KINEMATIC) {
+            if (this._autoUpdateIsometry &&
+                    (motionType === MOTION_TYPE_DYNAMIC || motionType === MOTION_TYPE_KINEMATIC)) {
                 this._isometryEvent = this.system.on('write-isometry', this.writeIsometry, this);
             }
         }

--- a/src/physics/jolt/front/body/system.mjs
+++ b/src/physics/jolt/front/body/system.mjs
@@ -32,7 +32,8 @@ const schema = [
     'allowDynamicOrKinematic',
     'isSensor',
     'motionQuality',
-    'allowSleeping'
+    'allowSleeping',
+    'autoUpdateIsometry'
 ];
 
 /**


### PR DESCRIPTION
Fixes: #41 

This PR adds an ability to stop `entity <> body` automatic synchronization.

```js
entity.addComponent('body', {
    motionType: MOTION_TYPE_KINEMATIC,
    objectLayer: OBJ_LAYER_MOVING,
    autoUpdateIsometry: false
});

// then on frame update, or when needed, move both - body and entity:
// entity
entity.setPosition(newPosition);
// and body, using one of the movement methods, e.g.:
entity.body.teleport(newPosition);
```

If set to `false`, the backend will no longer tell frontend where the dynamic body is, and frontend will not tell backend where a kinematic body is. No effect on static bodies (they don't move anyway).

This is useful when you have many kinematic objects, but rarely change their position/rotation. Then no need to update their isometry every frame.