### PR TITLE
Adds ability to consider scene depth per shape

### DIFF
--- a/src/physics/init.mjs
+++ b/src/physics/init.mjs
@@ -188,15 +188,6 @@ class JoltInitSettings {
     debugDrawLayerId;
 
     /**
-     * If `true`, debug draw will consider scene depth, so lines that are behind a visual mesh will
-     * not be drawn ontop of it.
-     *
-     * @type {boolean}
-     * @defaultValue true
-     */
-    debugDrawDepth;
-
-    /**
      * Makes the simulation deterministic at the cost of performance. Simulation runs faster, if
      * determinism is disabled.
      *

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -489,6 +489,7 @@ class Creator {
         body.autoUpdateIsometry = cb.read(BUFFER_READ_BOOL);
 
         if ($_DEBUG) {
+            body.debugDrawDepth = cb.read(BUFFER_READ_BOOL);
             this._addDebugDraw(cb.read(BUFFER_READ_BOOL), body);
         }
 
@@ -582,6 +583,7 @@ class Creator {
         bodyInterface.AddBody(body.GetID(), Jolt.EActivation_Activate);
 
         if ($_DEBUG) {
+            body.debugDrawDepth = cb.read(BUFFER_READ_BOOL);
             this._addDebugDraw(cb.read(BUFFER_READ_BOOL), body);
         }
 
@@ -691,6 +693,7 @@ class Creator {
         const character = new Jolt.CharacterVirtual(settings, jv, jq, backend.physicsSystem);
 
         if ($_DEBUG) {
+            character.debugDrawDepth = cb.read(BUFFER_READ_BOOL);
             this._addDebugDraw(cb.read(BUFFER_READ_BOOL), character);
         }
 

--- a/src/physics/jolt/back/operators/drawer.mjs
+++ b/src/physics/jolt/back/operators/drawer.mjs
@@ -83,11 +83,15 @@ class Drawer {
                     const buffer = Jolt.HEAPF32.buffer;
 
                     this._data.push(
-                        ...data, motionType, buffer,
+                        ...data, motionType, body.debugDrawDepth, buffer,
                         pos.GetX(), pos.GetY(), pos.GetZ(),
                         rot.GetX(), rot.GetY(), rot.GetZ(), rot.GetW()
                     );
-                    this._buffers.push(buffer);
+
+                    const index = this._buffers.indexOf(buffer);
+                    if (index < 0) {
+                        this._buffers.push(buffer);
+                    }
 
                     return true;
                 }
@@ -109,7 +113,7 @@ class Drawer {
             body.triContext = triContext;
 
             this._data.push(
-                index, length, byteOffset, motionType, buffer,
+                index, length, byteOffset, motionType, body.debugDrawDepth, buffer,
                 pos.GetX(), pos.GetY(), pos.GetZ(),
                 rot.GetX(), rot.GetY(), rot.GetZ(), rot.GetW()
             );

--- a/src/physics/jolt/back/operators/modifier.mjs
+++ b/src/physics/jolt/back/operators/modifier.mjs
@@ -8,11 +8,12 @@ import {
     CMD_CLAMP_LIN_VEL, CMD_MOVE_BODY, CMD_MOVE_KINEMATIC, CMD_RESET_MOTION, CMD_RESET_SLEEP_TIMER,
     CMD_SET_ALLOW_SLEEPING, CMD_SET_ANG_FACTOR, CMD_SET_ANG_VEL, CMD_SET_ANG_VEL_CLAMPED,
     CMD_SET_APPLY_GYRO_FORCE, CMD_SET_AUTO_UPDATE_ISOMETRY, CMD_SET_COL_GROUP, CMD_SET_DEBUG_DRAW,
-    CMD_SET_DOF, CMD_SET_FRICTION, CMD_SET_GRAVITY_FACTOR, CMD_SET_INTERNAL_EDGE, CMD_SET_IS_SENSOR,
-    CMD_SET_KIN_COL_NON_DYN, CMD_SET_LIN_VEL, CMD_SET_LIN_VEL_CLAMPED, CMD_SET_MAX_ANG_VEL,
-    CMD_SET_MAX_LIN_VEL, CMD_SET_MOTION_QUALITY, CMD_SET_MOTION_TYPE, CMD_SET_OBJ_LAYER,
-    CMD_SET_POS_STEPS, CMD_SET_RESTITUTION, CMD_SET_SHAPE, CMD_SET_VEL_STEPS, CMD_TOGGLE_GROUP_PAIR,
-    CMD_USE_MOTION_STATE, MOTION_QUALITY_DISCRETE, MOTION_TYPE_DYNAMIC, MOTION_TYPE_KINEMATIC
+    CMD_SET_DEBUG_DRAW_DEPTH, CMD_SET_DOF, CMD_SET_FRICTION, CMD_SET_GRAVITY_FACTOR,
+    CMD_SET_INTERNAL_EDGE, CMD_SET_IS_SENSOR, CMD_SET_KIN_COL_NON_DYN, CMD_SET_LIN_VEL,
+    CMD_SET_LIN_VEL_CLAMPED, CMD_SET_MAX_ANG_VEL, CMD_SET_MAX_LIN_VEL, CMD_SET_MOTION_QUALITY,
+    CMD_SET_MOTION_TYPE, CMD_SET_OBJ_LAYER, CMD_SET_POS_STEPS, CMD_SET_RESTITUTION, CMD_SET_SHAPE,
+    CMD_SET_VEL_STEPS, CMD_TOGGLE_GROUP_PAIR, CMD_USE_MOTION_STATE, MOTION_QUALITY_DISCRETE,
+    MOTION_TYPE_DYNAMIC, MOTION_TYPE_KINEMATIC
 } from '../../constants.mjs';
 import { Creator } from './creator.mjs';
 import { Cleaner } from './cleaner.mjs';
@@ -152,6 +153,10 @@ class Modifier {
 
             case CMD_SET_DEBUG_DRAW:
                 ok = this._setDebugDraw(cb);
+                break;
+
+            case CMD_SET_DEBUG_DRAW_DEPTH:
+                ok = this._setDebugDrawDepth(cb);
                 break;
 
             case CMD_SET_ALLOW_SLEEPING:
@@ -621,10 +626,6 @@ class Modifier {
     }
 
     _setDebugDraw(cb) {
-        if (!$_DEBUG) {
-            return true;
-        }
-
         const body = this._getBody(cb);
         const toDraw = cb.read(BUFFER_READ_BOOL);
         const debugBodies = this._backend.tracker.debug;
@@ -642,6 +643,14 @@ class Modifier {
             }
             return false;
         }
+
+        return true;
+    }
+
+    _setDebugDrawDepth(cb) {
+        const body = this._getBody(cb);
+
+        body.debugDrawDepth = cb.read(BUFFER_READ_BOOL);
 
         return true;
     }

--- a/src/physics/jolt/constants.mjs
+++ b/src/physics/jolt/constants.mjs
@@ -188,6 +188,7 @@ export const CMD_SET_VEL_STEPS = 57;
 export const CMD_SET_POS_STEPS = 58;
 export const CMD_SET_SHAPE = 59;
 export const CMD_SET_DEBUG_DRAW = 60;
+export const CMD_SET_DEBUG_DRAW_DEPTH = 61;
 
 
 // Char Virtual 400-499

--- a/src/physics/jolt/front/body/component.mjs
+++ b/src/physics/jolt/front/body/component.mjs
@@ -1442,6 +1442,7 @@ class BodyComponent extends ShapeComponent {
         cb.write(this._autoUpdateIsometry, BUFFER_WRITE_BOOL, false);
 
         if ($_DEBUG) {
+            cb.write(this._debugDrawDepth, BUFFER_WRITE_BOOL, false);
             cb.write(this._debugDraw, BUFFER_WRITE_BOOL, false);
         }
     }

--- a/src/physics/jolt/front/char/component.mjs
+++ b/src/physics/jolt/front/char/component.mjs
@@ -714,6 +714,7 @@ class CharComponent extends ShapeComponent {
         cb.write(rot, BUFFER_WRITE_VEC32, false);
 
         if ($_DEBUG) {
+            cb.write(this._debugDrawDepth, BUFFER_WRITE_BOOL, false);
             cb.write(this._debugDraw, BUFFER_WRITE_BOOL, false);
         }
     }

--- a/src/physics/jolt/front/shape/component.mjs
+++ b/src/physics/jolt/front/shape/component.mjs
@@ -3,9 +3,9 @@ import { Debug } from '../../debug.mjs';
 import { Component } from '../component.mjs';
 import {
     BUFFER_WRITE_BOOL, BUFFER_WRITE_FLOAT32, BUFFER_WRITE_UINT32, BUFFER_WRITE_UINT8,
-    BUFFER_WRITE_VEC32, CMD_SET_DEBUG_DRAW, CMD_SET_SHAPE, FLOAT32_SIZE, OPERATOR_MODIFIER,
-    SHAPE_BOX, SHAPE_CAPSULE, SHAPE_CONVEX_HULL, SHAPE_CYLINDER, SHAPE_HEIGHTFIELD, SHAPE_MESH,
-    SHAPE_SPHERE, SHAPE_STATIC_COMPOUND
+    BUFFER_WRITE_VEC32, CMD_SET_DEBUG_DRAW, CMD_SET_DEBUG_DRAW_DEPTH, CMD_SET_SHAPE, FLOAT32_SIZE,
+    OPERATOR_MODIFIER, SHAPE_BOX, SHAPE_CAPSULE, SHAPE_CONVEX_HULL, SHAPE_CYLINDER,
+    SHAPE_HEIGHTFIELD, SHAPE_MESH, SHAPE_SPHERE, SHAPE_STATIC_COMPOUND
 } from '../../constants.mjs';
 
 const defaultHalfExtent = new Vec3(0.5, 0.5, 0.5);
@@ -86,25 +86,25 @@ class ShapeComponent extends Component {
      * @param {boolean} bool - Boolean to enable/disable a debug draw.
      */
     set debugDraw(bool) {
+        if (!$_DEBUG) {
+            this._debugDraw = false;
+            return;
+        }
+
         if (this._debugDraw === bool) {
             return;
         }
 
-        // Debug draw is only available in a debug build.
-        if ($_DEBUG) {
-            const ok = Debug.checkBool(bool, `Invalid debug draw bool: ${bool}`);
-            if (!ok) {
-                return;
-            }
-
-            this._debugDraw = bool;
-            this.system.addCommand(
-                OPERATOR_MODIFIER, CMD_SET_DEBUG_DRAW, this._index,
-                bool, BUFFER_WRITE_BOOL, false
-            );
-        } else {
-            this._debugDraw = false;
+        const ok = Debug.checkBool(bool);
+        if (!ok) {
+            return;
         }
+
+        this._debugDraw = bool;
+        this.system.addCommand(
+            OPERATOR_MODIFIER, CMD_SET_DEBUG_DRAW, this._index,
+            bool, BUFFER_WRITE_BOOL, false
+        );
     }
 
     /**
@@ -124,7 +124,20 @@ class ShapeComponent extends Component {
      * @param {boolean} bool - Boolean, telling whether to consider scene depth.
      */
     set debugDrawDepth(bool) {
-        this._debugDraw = bool;
+        if (!$_DEBUG || this._debugDrawDepth === bool) {
+            return;
+        }
+
+        const ok = Debug.checkBool(bool);
+        if (!ok) {
+            return;
+        }
+
+        this._debugDrawDepth = bool;
+        this.system.addCommand(
+            OPERATOR_MODIFIER, CMD_SET_DEBUG_DRAW_DEPTH, this._index,
+            bool, BUFFER_WRITE_BOOL, false
+        );
     }
 
     /**
@@ -132,7 +145,7 @@ class ShapeComponent extends Component {
      * @defaultValue true
      */
     get debugDrawDepth() {
-        return this._debugDraw;
+        return this._debugDrawDepth;
     }
 
     /**

--- a/src/physics/jolt/front/shape/component.mjs
+++ b/src/physics/jolt/front/shape/component.mjs
@@ -22,6 +22,8 @@ class ShapeComponent extends Component {
 
     _debugDraw = false;
 
+    _debugDrawDepth = true;
+
     _density = 1000;
 
     _halfExtent = defaultHalfExtent;
@@ -112,6 +114,24 @@ class ShapeComponent extends Component {
      * @defaultValue false
      */
     get debugDraw() {
+        return this._debugDraw;
+    }
+
+    /**
+     * If {@link debugDraw} is enabled, this will specify whether to consider scene depth or not.
+     * If set to `false`, the debug lines will be drawn on top of everything, through other meshes.
+     *
+     * @param {boolean} bool - Boolean, telling whether to consider scene depth.
+     */
+    set debugDrawDepth(bool) {
+        this._debugDraw = bool;
+    }
+
+    /**
+     * @type {boolean}
+     * @defaultValue true
+     */
+    get debugDrawDepth() {
         return this._debugDraw;
     }
 

--- a/src/physics/jolt/front/shape/system.mjs
+++ b/src/physics/jolt/front/shape/system.mjs
@@ -15,6 +15,7 @@ const schema = [
     'useEntityScale',
     'useMotionState',
     'debugDraw',
+    'debugDrawDepth',
 
     // Jolt shape
     'shape',

--- a/src/physics/jolt/front/softbody/component.mjs
+++ b/src/physics/jolt/front/softbody/component.mjs
@@ -152,6 +152,7 @@ class SoftBodyComponent extends BodyComponent {
         cb.write(this._allowSleeping, BUFFER_WRITE_BOOL, false);
 
         if ($_DEBUG) {
+            cb.write(this._debugDrawDepth, BUFFER_WRITE_BOOL, false);
             cb.write(this._debugDraw, BUFFER_WRITE_BOOL, false);
         }
     }

--- a/src/physics/jolt/manager.mjs
+++ b/src/physics/jolt/manager.mjs
@@ -33,7 +33,6 @@ function getColor(type, config) {
 }
 
 function debugDraw(app, data, config) {
-    const useDepth = config.debugDrawDepth;
     const layer = app.scene.layers.getLayerById(config.debugDrawLayerId);
     const tempVectors = ShapeComponentSystem.tempVectors;
 
@@ -47,17 +46,18 @@ function debugDraw(app, data, config) {
     const v4 = tempVectors[3];
     const q1 = tempVectors[4];
 
-    for (let d = 0, total = data.length; d < total; d += 12) {
+    for (let d = 0, total = data.length; d < total; d += 13) {
         const length = data[d + 1];
         const byteOffset = data[d + 2];
         const motionType = data[d + 3];
-        const buffer = data[d + 4];
+        const depth = data[d + 4];
+        const buffer = data[d + 5];
 
         const view = new Float32Array(buffer, byteOffset, length);
         const color = getColor(motionType, config);
 
-        const p = v4.set(data[d + 5], data[d + 6], data[d + 7]);
-        const r = q1.set(data[d + 8], data[d + 9], data[d + 10], data[d + 11]);
+        const p = v4.set(data[d + 6], data[d + 7], data[d + 8]);
+        const r = q1.set(data[d + 9], data[d + 10], data[d + 11], data[d + 12]);
 
         for (let i = 0, end = view.length; i < end; i += 9) {
             v1.set(view[i], view[i + 1], view[i + 2]);
@@ -71,9 +71,9 @@ function debugDraw(app, data, config) {
             v2.add(p);
             v3.add(p);
 
-            app.drawLine(v1, v2, color, useDepth, layer);
-            app.drawLine(v2, v3, color, useDepth, layer);
-            app.drawLine(v3, v1, color, useDepth, layer);
+            app.drawLine(v1, v2, color, depth, layer);
+            app.drawLine(v2, v3, color, depth, layer);
+            app.drawLine(v3, v1, color, depth, layer);
         }
     }
 }


### PR DESCRIPTION
Fixes: #69 

Adds ability to define whether to debug draw considers scene depth or not on a shape level.

```js
entity.addComponent('body', { debugDraw: true, debugDrawDepth: false });

entity.body.debugDrawDepth = true; // false;
```