### PR TITLE
Mutable compound shape

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@gamebop/physics",
     "description": "Physics components for PlayCanvas engine",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "main": "dist/physics.min.mjs",
     "author": "Gamebop",
     "license": "MIT",

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -365,6 +365,9 @@ class Creator {
         const shape = shapeResult.Get();
         shape.AddRef();
 
+        // mark it for release, e.g. when removing a child from compound shape
+        shape.needsRelease = true;
+
         this._backend.tracker.shapeMap.set(num, shape);
 
         return true;

--- a/src/physics/jolt/back/operators/helpers/char-modifier.mjs
+++ b/src/physics/jolt/back/operators/helpers/char-modifier.mjs
@@ -9,6 +9,7 @@ import {
     CMD_CHAR_SET_COS_ANGLE, CMD_CHAR_SET_MIN_DIST, CMD_CHAR_SET_TEST_DIST, CMD_CHAR_SET_EXTRA_DOWN,
     CMD_CHAR_SET_STEP_UP, CMD_CHAR_SET_STICK_DOWN
 } from '../../../constants.mjs';
+import { Cleaner } from '../cleaner.mjs';
 
 class CharModifier {
     _modifier = null;
@@ -18,6 +19,7 @@ class CharModifier {
     constructor(modifier) {
         this._modifier = modifier;
         this._tracker = modifier.backend.tracker;
+        this._cleaner = modifier.backend.cleaner;
     }
 
     modify(command, cb) {
@@ -194,7 +196,7 @@ class CharModifier {
             }
 
             // invalidate current debug draw, so we draw a new shape instead
-            char.debugDrawData = null;
+            Cleaner.cleanDebugDrawData(char, backend.Jolt);
         }
 
         let shape;

--- a/src/physics/jolt/back/operators/modifier.mjs
+++ b/src/physics/jolt/back/operators/modifier.mjs
@@ -359,7 +359,6 @@ class Modifier {
 
     _addShape(cb) {
         const backend = this._backend;
-        const bodyInterface = backend.bodyInterface;
         const Jolt = backend.Jolt;
         const body = this._getBody(cb);
         const jv = this._joltVec3_1;
@@ -411,7 +410,6 @@ class Modifier {
 
     _removeShape(cb) {
         const backend = this._backend;
-        const bodyInterface = backend.bodyInterface;
         const Jolt = backend.Jolt;
         const body = this._getBody(cb);
 
@@ -429,7 +427,7 @@ class Modifier {
                     return false;
                 }
             }
-            
+
             const childShapesCount = compoundShape.GetNumSubShapes();
             if (childIndex > childShapesCount - 1) {
                 if ($_DEBUG) {
@@ -448,7 +446,7 @@ class Modifier {
             if (shape.needsRelease) {
                 shape.Release();
             }
-            
+
             Cleaner.cleanDebugDrawData(body, Jolt);
         } catch (e) {
             if ($_DEBUG) {
@@ -462,7 +460,6 @@ class Modifier {
 
     _modifyShape(cb) {
         const backend = this._backend;
-        const bodyInterface = backend.bodyInterface;
         const Jolt = backend.Jolt;
         const body = this._getBody(cb);
         const jv = this._joltVec3_1;
@@ -470,12 +467,12 @@ class Modifier {
 
         try {
             const childIndex = cb.read(BUFFER_READ_UINT32);
-            
+
             jv.FromBuffer(cb);
             jq.FromBuffer(cb);
 
             const bodyShape = body.GetShape();
-            
+
             if ($_DEBUG) {
                 const isValid = bodyShape.GetType() === Jolt.EShapeType_Compound &&
                 bodyShape.GetSubType() === Jolt.EShapeSubType_MutableCompound;
@@ -484,7 +481,7 @@ class Modifier {
                     return false;
                 }
             }
-            
+
             let shape;
             if (cb.flag) {
                 const shapeIndex = cb.read(BUFFER_READ_UINT32);

--- a/src/physics/jolt/constants.mjs
+++ b/src/physics/jolt/constants.mjs
@@ -191,6 +191,7 @@ export const CMD_SET_SHAPE = 59;
 export const CMD_SET_DEBUG_DRAW = 60;
 export const CMD_SET_DEBUG_DRAW_DEPTH = 61;
 export const CMD_ADD_SHAPE = 62;
+export const CMD_REMOVE_SHAPE = 63;
 
 
 // Char Virtual 400-499

--- a/src/physics/jolt/constants.mjs
+++ b/src/physics/jolt/constants.mjs
@@ -192,6 +192,7 @@ export const CMD_SET_DEBUG_DRAW = 60;
 export const CMD_SET_DEBUG_DRAW_DEPTH = 61;
 export const CMD_ADD_SHAPE = 62;
 export const CMD_REMOVE_SHAPE = 63;
+export const CMD_MODIFY_SHAPE = 64;
 
 
 // Char Virtual 400-499

--- a/src/physics/jolt/constants.mjs
+++ b/src/physics/jolt/constants.mjs
@@ -89,6 +89,7 @@ export const SHAPE_MESH = 4;
 export const SHAPE_CONVEX_HULL = 5;
 export const SHAPE_HEIGHTFIELD = 6;
 export const SHAPE_STATIC_COMPOUND = 7;
+export const SHAPE_MUTABLE_COMPOUND = 8;
 
 export const CONTACT_TYPE_ADDED = 0;
 export const CONTACT_TYPE_PERSISTED = 1;
@@ -189,6 +190,7 @@ export const CMD_SET_POS_STEPS = 58;
 export const CMD_SET_SHAPE = 59;
 export const CMD_SET_DEBUG_DRAW = 60;
 export const CMD_SET_DEBUG_DRAW_DEPTH = 61;
+export const CMD_ADD_SHAPE = 62;
 
 
 // Char Virtual 400-499

--- a/src/physics/jolt/front/shape/component.mjs
+++ b/src/physics/jolt/front/shape/component.mjs
@@ -534,7 +534,7 @@ class ShapeComponent extends Component {
 
         this.system.addCommand(
             OPERATOR_MODIFIER, CMD_REMOVE_SHAPE, this._index,
-            childIndex, BUFFER_WRITE_UINT32, false,
+            childIndex, BUFFER_WRITE_UINT32, false
         );
     }
 

--- a/src/physics/jolt/manager.mjs
+++ b/src/physics/jolt/manager.mjs
@@ -87,7 +87,7 @@ function debugDraw(app, data, config) {
  * @category Jolt
  */
 class JoltManager extends PhysicsManager {
-    defaultHalfExtent = new Vec3(0.5, 0.5, 0.5);
+    static defaultHalfExtent = new Vec3(0.5, 0.5, 0.5);
 
     constructor(app, opts, resolve) {
         const config = {


### PR DESCRIPTION
PR adds support for a mutable compound shape. In contrast with the static compound shape, this shape allows to add/remove/modify its children shapes after creation.

```js
entity.addComponent('body', {
    shape: SHAPE_MUTABLE_COMPOUND
});


// can add new shapes to it
const shapeIndex = app.physics.createShape({ shape: SHAPE_SPHERE });
entity.body.addShape(shapeIndex, localPosition, localRotation);

// remove a child shape
entity.body.removeShape(childIndex);

// modify a child shape
entity.body.modifyShape(childIndex, localPosition, localRotation);
```