### PR TITLE
Bit mask filtering

### DIFF
--- a/src/physics/init.mjs
+++ b/src/physics/init.mjs
@@ -81,6 +81,8 @@ class JoltInitSettings {
      * await init(app, {
      *     fixedStep: 1 / 30,
      *     // ... other options,
+     *     
+     *     // Each pair in array is a broadphase layer: [included groups, excluded groups]
      *     bitFiltering: [
      *         GROUP_STATIC, 0,
      *         GROUP_FLOOR1 | GROUP_FLOOR2 | GROUP_FLOOR3, 0

--- a/src/physics/init.mjs
+++ b/src/physics/init.mjs
@@ -81,7 +81,7 @@ class JoltInitSettings {
      * await init(app, {
      *     fixedStep: 1 / 30,
      *     // ... other options,
-     *     
+     *
      *     // Each pair in array is a broadphase layer: [included groups, excluded groups]
      *     bitFiltering: [
      *         GROUP_STATIC, 0,

--- a/src/physics/init.mjs
+++ b/src/physics/init.mjs
@@ -48,6 +48,63 @@ class JoltInitSettings {
     baumgarte;
 
     /**
+     * Enables objects filtering using group and mask bits, similar to Bullet, Rapier, etc. If
+     * provided, it will disable default filtering. Uses group bits and mask bits to find collision
+     * pairs. Two layers can collide if `object1.group` and `object2.mask` is non-zero and
+     * `object2.group` and `object1.mask` is non-zero.
+     *
+     * Default Jolt build uses 16 bits for group filtering. In case you need more groups, you can
+     * compile it with additional flag to enable 32 bits. Refer to official Jolt documentation for
+     * building details.
+     *
+     * Group - an object group the object belongs to.
+     * Mask - object groups the object can collide with.
+     *
+     * To enable the bits filtering, you should provide an array of numbers, where elements are
+     * read in pairs:
+     * - Each pair forms a new broadphase layer.
+     * - First element of the pair are the groups to be included in that layer.
+     * - Second element of the pair are the groups to be excluded from that layer.
+     *
+     * @example
+     * ```js
+     * // Layer that objects can be in, determines which other objects it can collide with
+     * // Typically you at least want to have 1 layer for moving bodies and 1 layer for static bodies, but you can have more
+     * // layers if you want.
+     * const GROUP_STATIC = 1;
+     * const GROUP_FLOOR1 = 2;
+     * const GROUP_FLOOR2 = 4;
+     * const GROUP_FLOOR3 = 8;
+     * const GROUP_ALL = GROUP_STATIC | GROUP_FLOOR1 | GROUP_FLOOR2 | GROUP_FLOOR3;
+     *
+     * // init physics
+     * await init(app, {
+     *     fixedStep: 1 / 30,
+     *     // ... other options,
+     *     bitFiltering: [
+     *         GROUP_STATIC, 0,
+     *         GROUP_FLOOR1 | GROUP_FLOOR2 | GROUP_FLOOR3, 0
+     *     ]
+     * });
+     *
+     * // create floor that collides with everything
+     * floorEntity.addComponent('body', {
+     *     group: GROUP_STATIC,
+     *     mask: GROUP_ALL
+     * });
+     *
+     * // create a dynamic body that collides with a floor GROUP_FLOOR2
+     * dynamicEntity.addComponent('body', {
+     *     group: GROUP_FLOOR2,
+     *     mask: GROUP_ALL
+     * });
+     * ```
+     * @type {Array<number> | null}
+     * @defaultValue null
+     */
+    bitFiltering;
+
+    /**
      * Maximum relative delta orientation for body pairs to be able to reuse collision results from
      * last update, stored as
      * ```

--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -62,6 +62,7 @@ class JoltBackend {
             contactRemovedEventsEnabled: true,
             contactPoints: true,
             contactPointsAveraged: true,
+            bitFiltering: null,
             broadPhaseLayers: [BP_LAYER_NON_MOVING, BP_LAYER_MOVING],
             // object layer vs object layer
             objectLayerPairs: [

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -754,7 +754,7 @@ class Creator {
             const objectVsBroadPhaseLayerFilter = joltInterface.GetObjectVsBroadPhaseLayerFilter();
             const objectLayerPairFilter = joltInterface.GetObjectLayerPairFilter();
             const objectLayer = backend.Jolt.ObjectLayerPairFilterMask.prototype.sGetObjectLayer(group, mask);
-            
+
             character.bpFilter = new Jolt.DefaultBroadPhaseLayerFilter(objectVsBroadPhaseLayerFilter, objectLayer);
             character.objFilter = new Jolt.DefaultObjectLayerFilter(objectLayerPairFilter, objectLayer);
         } else {

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -255,46 +255,62 @@ class Creator {
         const Jolt = backend.Jolt;
 
         this._joltVec3 = new Jolt.Vec3();
-        this._joltVec3_2 = new Jolt.Vec3();
         this._joltQuat = new Jolt.Quat();
 
-        const bpMap = new Map();
-        const pairs = config.objectLayerPairs;
-        const pairsCount = pairs.length * 0.5;
-        const objectFilter = new Jolt.ObjectLayerPairFilterTable(pairsCount);
-        for (let i = 0; i < pairsCount * 2; i += 2) {
-            objectFilter.EnableCollision(pairs[i], pairs[i + 1]);
-        }
-
-        const bpLayers = config.broadPhaseLayers;
-        const bpLayerCount = bpLayers.length;
-        const bpInterface = new Jolt.BroadPhaseLayerInterfaceTable(pairsCount, bpLayerCount);
-        for (let i = 0; i < bpLayerCount; i++) {
-            const id = bpLayers[i];
-            const bpLayer = new Jolt.BroadPhaseLayer(id);
-            bpMap.set(id, bpLayer);
-        }
-
-        // Map object layers to broadphase layers
-        let objLayerCount = 0;
-        const objLayers = config.mapObjectToBroadPhaseLayer;
-        for (let i = 0; i < objLayers.length; i += 2) {
-            objLayerCount++;
-            bpInterface.MapObjectToBroadPhaseLayer(objLayers[i], bpMap.get(objLayers[i + 1]));
-        }
-        // Broadphase layers have been copied to the bpInterface, so we can destroy those
-        bpMap.forEach((bpLayer) => {
-            Jolt.destroy(bpLayer);
-        });
-        bpMap.clear();
-
         const settings = new Jolt.JoltSettings();
-        settings.mObjectLayerPairFilter = objectFilter;
-        settings.mBroadPhaseLayerInterface = bpInterface;
-        settings.mObjectVsBroadPhaseLayerFilter = new Jolt.ObjectVsBroadPhaseLayerFilterTable(settings.mBroadPhaseLayerInterface,
-                                                                                              bpLayerCount,
-                                                                                              settings.mObjectLayerPairFilter,
-                                                                                              objLayerCount);
+        const bitFiltering = config.bitFiltering;
+
+        if (bitFiltering) {
+            const count = bitFiltering.length;
+            const bpInterface = new Jolt.BroadPhaseLayerInterfaceMask(count * 0.5);
+
+            for (let i = 0; i < count; i += 2) {
+                bpInterface.ConfigureLayer(new Jolt.BroadPhaseLayer(i * 0.5), bitFiltering[i], bitFiltering[i + 1]);
+            }
+
+            settings.mObjectLayerPairFilter = new Jolt.ObjectLayerPairFilterMask();
+            settings.mBroadPhaseLayerInterface = bpInterface;
+            settings.mObjectVsBroadPhaseLayerFilter = new Jolt.ObjectVsBroadPhaseLayerFilterMask(bpInterface);
+        } else {
+            const bpMap = new Map();
+            const pairs = config.objectLayerPairs;
+            const pairsCount = pairs.length * 0.5;
+            const objectFilter = new Jolt.ObjectLayerPairFilterTable(pairsCount);
+            for (let i = 0; i < pairsCount * 2; i += 2) {
+                objectFilter.EnableCollision(pairs[i], pairs[i + 1]);
+            }
+
+            const bpLayers = config.broadPhaseLayers;
+            const bpLayerCount = bpLayers.length;
+            const bpInterface = new Jolt.BroadPhaseLayerInterfaceTable(pairsCount, bpLayerCount);
+            for (let i = 0; i < bpLayerCount; i++) {
+                const id = bpLayers[i];
+                const bpLayer = new Jolt.BroadPhaseLayer(id);
+                bpMap.set(id, bpLayer);
+            }
+
+            // Map object layers to broadphase layers
+            let objLayerCount = 0;
+            const objLayers = config.mapObjectToBroadPhaseLayer;
+            for (let i = 0; i < objLayers.length; i += 2) {
+                objLayerCount++;
+                bpInterface.MapObjectToBroadPhaseLayer(objLayers[i], bpMap.get(objLayers[i + 1]));
+            }
+            // Broadphase layers have been copied to the bpInterface, so we can destroy those
+            bpMap.forEach((bpLayer) => {
+                Jolt.destroy(bpLayer);
+            });
+            bpMap.clear();
+
+            settings.mObjectLayerPairFilter = objectFilter;
+            settings.mBroadPhaseLayerInterface = bpInterface;
+            settings.mObjectVsBroadPhaseLayerFilter =
+                new Jolt.ObjectVsBroadPhaseLayerFilterTable(settings.mBroadPhaseLayerInterface,
+                                                            bpLayerCount,
+                                                            settings.mObjectLayerPairFilter,
+                                                            objLayerCount);
+        }
+
         const joltInterface = new Jolt.JoltInterface(settings);
         Jolt.destroy(settings);
 
@@ -342,8 +358,12 @@ class Creator {
     }
 
     destroy() {
-        Jolt.destroy(this._joltVec3);
-        Jolt.destroy(this._joltQuat);
+        if (this._joltVec3) {
+            Jolt.destroy(this._joltVec3);
+        }
+        if (this._joltQuat) {
+            Jolt.destroy(this._joltQuat);
+        }
     }
 
     // TODO
@@ -378,6 +398,7 @@ class Creator {
         const jv = this._joltVec3;
         const jq = this._joltQuat;
         const Jolt = backend.Jolt;
+        const config = backend.config;
 
         // ------------ SHAPE PROPS ----------------
 
@@ -415,8 +436,16 @@ class Creator {
         // use motion state
         const useMotionState = cb.read(BUFFER_READ_BOOL);
 
+        // bit filtering
+        const group = cb.read(BUFFER_READ_UINT32);
+        const mask = cb.read(BUFFER_READ_UINT32);
+
         // object layer
-        const objectLayer = cb.read(BUFFER_READ_UINT32);
+        let objectLayer = cb.read(BUFFER_READ_UINT32);
+        if (!!config.bitFiltering) {
+            objectLayer = Jolt.ObjectLayerPairFilterMask.prototype.sGetObjectLayer(group, mask);
+        }
+
         const bodyCreationSettings = new Jolt.BodyCreationSettings(shape, jv, jq, jmt, objectLayer);
 
         bodyCreationSettings.mLinearVelocity = jv.FromBuffer(cb);
@@ -441,18 +470,20 @@ class Creator {
 
         // collision group
         const hasCollisionGroup = cb.read(BUFFER_READ_BOOL);
-        const group = hasCollisionGroup ? cb.read(BUFFER_READ_UINT32) : null;
+        const colGroup = hasCollisionGroup ? cb.read(BUFFER_READ_UINT32) : null;
 
         // collision sub group
         const hasSubGroup = cb.read(BUFFER_READ_BOOL);
         const subGroup = hasSubGroup ? cb.read(BUFFER_READ_UINT32) : null;
 
-        if (group !== null && subGroup !== null) {
-            const table = backend.groupFilterTables[group];
+        if (!config.bitFiltering && colGroup !== null && subGroup !== null) {
+            const table = backend.groupFilterTables[colGroup];
 
             if ($_DEBUG) {
-                let ok = Debug.assert(!!table, `Trying to set a filter group that does not exist: ${group}`);
-                ok = ok && Debug.assert((subGroup <= table?.maxIndex), `Trying to set sub group that is over the filter group table size: ${subGroup}`);
+                let ok = Debug.assert(!!table, `Trying to set a filter group that does not exist:` +
+                    `${colGroup}`);
+                ok = ok && Debug.assert((subGroup <= table?.maxIndex), `Trying to set sub group` +
+                    ` that is over the filter group table size: ${subGroup}`);
                 if (!ok) {
                     return false;
                 }
@@ -460,7 +491,7 @@ class Creator {
 
             const mCollisionGroup = bodyCreationSettings.mCollisionGroup;
             mCollisionGroup.SetGroupFilter(table);
-            mCollisionGroup.SetGroupID(group);
+            mCollisionGroup.SetGroupID(colGroup);
             mCollisionGroup.SetSubGroupID(subGroup);
         }
 
@@ -498,7 +529,7 @@ class Creator {
 
         if ($_DEBUG) {
             body.debugDrawDepth = cb.read(BUFFER_READ_BOOL);
-            body.debugDraw = cb.read(BUFFER_READ_BOOL) && !backend.config.useWebWorker;
+            body.debugDraw = cb.read(BUFFER_READ_BOOL) && !config.useWebWorker;
         }
 
         // Destroy shape settings after body is created:

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -749,26 +749,14 @@ class Creator {
         character.bpFilter = bpLayer !== BP_LAYER_MOVING ? new Jolt.DefaultBroadPhaseLayerFilter(
             joltInterface.GetObjectVsBroadPhaseLayerFilter(), bpLayer) : null;
 
-        
-
-        // TODO
-
         const bitFiltering = config.bitFiltering;
         if (!!bitFiltering) {
-            // const count = bitFiltering.length;
-            // const bpInterface = new Jolt.BroadPhaseLayerInterfaceMask(count * 0.5);
-
-            // for (let i = 0; i < count; i += 2) {
-            //     bpInterface.ConfigureLayer(new Jolt.BroadPhaseLayer(i * 0.5), bitFiltering[i], bitFiltering[i + 1]);
-            // }
-
-            // settings.mObjectLayerPairFilter = new Jolt.ObjectLayerPairFilterMask();
-            // settings.mBroadPhaseLayerInterface = bpInterface;
-            // settings.mObjectVsBroadPhaseLayerFilter = new Jolt.ObjectVsBroadPhaseLayerFilterMask(bpInterface);
-
+            const objectVsBroadPhaseLayerFilter = joltInterface.GetObjectVsBroadPhaseLayerFilter();
+            const objectLayerPairFilter = joltInterface.GetObjectLayerPairFilter();
             const objectLayer = backend.Jolt.ObjectLayerPairFilterMask.prototype.sGetObjectLayer(group, mask);
-            character.objFilter = new Jolt.DefaultObjectLayerFilter(new Jolt.ObjectLayerPairFilterMask(),
-                                                                    objectLayer);
+            
+            character.bpFilter = new Jolt.DefaultBroadPhaseLayerFilter(objectVsBroadPhaseLayerFilter, objectLayer);
+            character.objFilter = new Jolt.DefaultObjectLayerFilter(objectLayerPairFilter, objectLayer);
         } else {
             character.objFilter = objLayer !== OBJ_LAYER_MOVING ? new Jolt.DefaultObjectLayerFilter(
                 joltInterface.GetObjectLayerPairFilter(), objLayer) : null;

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -743,11 +743,36 @@ class Creator {
         const bpLayer = cb.read(BUFFER_READ_UINT16);
         const objLayer = cb.read(BUFFER_READ_UINT16);
 
+        const group = cb.read(BUFFER_READ_UINT32);
+        const mask = cb.read(BUFFER_READ_UINT32);
+
         character.bpFilter = bpLayer !== BP_LAYER_MOVING ? new Jolt.DefaultBroadPhaseLayerFilter(
             joltInterface.GetObjectVsBroadPhaseLayerFilter(), bpLayer) : null;
 
-        character.objFilter = objLayer !== OBJ_LAYER_MOVING ? new Jolt.DefaultObjectLayerFilter(
-            joltInterface.GetObjectLayerPairFilter(), objLayer) : null;
+        
+
+        // TODO
+
+        const bitFiltering = config.bitFiltering;
+        if (!!bitFiltering) {
+            // const count = bitFiltering.length;
+            // const bpInterface = new Jolt.BroadPhaseLayerInterfaceMask(count * 0.5);
+
+            // for (let i = 0; i < count; i += 2) {
+            //     bpInterface.ConfigureLayer(new Jolt.BroadPhaseLayer(i * 0.5), bitFiltering[i], bitFiltering[i + 1]);
+            // }
+
+            // settings.mObjectLayerPairFilter = new Jolt.ObjectLayerPairFilterMask();
+            // settings.mBroadPhaseLayerInterface = bpInterface;
+            // settings.mObjectVsBroadPhaseLayerFilter = new Jolt.ObjectVsBroadPhaseLayerFilterMask(bpInterface);
+
+            const objectLayer = backend.Jolt.ObjectLayerPairFilterMask.prototype.sGetObjectLayer(group, mask);
+            character.objFilter = new Jolt.DefaultObjectLayerFilter(new Jolt.ObjectLayerPairFilterMask(),
+                                                                    objectLayer);
+        } else {
+            character.objFilter = objLayer !== OBJ_LAYER_MOVING ? new Jolt.DefaultObjectLayerFilter(
+                joltInterface.GetObjectLayerPairFilter(), objLayer) : null;
+        }
 
         character.updateSettings = updateSettings;
 
@@ -756,7 +781,7 @@ class Creator {
             character.debugDraw = cb.read(BUFFER_READ_BOOL) && !config.useWebWorker;
         }
 
-        if (backend.config.useMotionStates && useMotionState) {
+        if (config.useMotionStates && useMotionState) {
             character.motionState = new MotionState(character);
         }
 

--- a/src/physics/jolt/back/operators/helpers/char-modifier.mjs
+++ b/src/physics/jolt/back/operators/helpers/char-modifier.mjs
@@ -66,7 +66,7 @@ class CharModifier {
 
             case CMD_CHAR_SET_OBJ_FILTER_LAYER:
                 return this._setObjFilterLayer(cb);
-            
+
             case CMD_CHAR_UPDATE_BIT_FILTER:
                 return this._updateBitFilter(cb);
 

--- a/src/physics/jolt/back/operators/helpers/char-modifier.mjs
+++ b/src/physics/jolt/back/operators/helpers/char-modifier.mjs
@@ -397,7 +397,7 @@ class CharModifier {
         return true;
     }
 
-    _setObjFilterLayer(cb) {
+    _updateBitFilter(cb) {
         const char = this._tracker.getBodyByPCID(cb.read(BUFFER_READ_UINT32));
         const backend = this._modifier.backend;
         const Jolt = backend.Jolt;
@@ -414,9 +414,9 @@ class CharModifier {
                 Jolt.destroy(char.objFilter);
             }
 
+            const objectLayerPairFilter = backend.joltInterface.GetObjectLayerPairFilter();
             const objectLayer = Jolt.ObjectLayerPairFilterMask.prototype.sGetObjectLayer(group, mask);
-            char.objFilter = new Jolt.DefaultObjectLayerFilter(
-                    backend.joltInterface.GetObjectLayerPairFilter(), objectLayer);
+            char.objFilter = new Jolt.DefaultObjectLayerFilter(objectLayerPairFilter, objectLayer);
         } catch (e) {
             if ($_DEBUG) {
                 Debug.error(e);

--- a/src/physics/jolt/constants.mjs
+++ b/src/physics/jolt/constants.mjs
@@ -193,6 +193,7 @@ export const CMD_SET_DEBUG_DRAW_DEPTH = 61;
 export const CMD_ADD_SHAPE = 62;
 export const CMD_REMOVE_SHAPE = 63;
 export const CMD_MODIFY_SHAPE = 64;
+export const CMD_UPDATE_BIT_FILTER = 65;
 
 
 // Char Virtual 400-499

--- a/src/physics/jolt/constants.mjs
+++ b/src/physics/jolt/constants.mjs
@@ -209,14 +209,15 @@ export const CMD_CHAR_SET_HIT_RED_ANGLE = 408;
 export const CMD_CHAR_SET_SHAPE_OFFSET = 409;
 export const CMD_CHAR_SET_USER_DATA = 410;
 export const CMD_CHAR_SET_UP = 411;
-export const CMD_CHAR_SET_BP_FILTER_LAYER = 422;
-export const CMD_CHAR_SET_OBJ_FILTER_LAYER = 423;
-export const CMD_CHAR_SET_COS_ANGLE = 424;
-export const CMD_CHAR_SET_MIN_DIST = 425;
-export const CMD_CHAR_SET_TEST_DIST = 426;
-export const CMD_CHAR_SET_EXTRA_DOWN = 427;
-export const CMD_CHAR_SET_STEP_UP = 428;
-export const CMD_CHAR_SET_STICK_DOWN = 429;
+export const CMD_CHAR_SET_BP_FILTER_LAYER = 412;
+export const CMD_CHAR_SET_OBJ_FILTER_LAYER = 413;
+export const CMD_CHAR_SET_COS_ANGLE = 414;
+export const CMD_CHAR_SET_MIN_DIST = 415;
+export const CMD_CHAR_SET_TEST_DIST = 416;
+export const CMD_CHAR_SET_EXTRA_DOWN = 417;
+export const CMD_CHAR_SET_STEP_UP = 418;
+export const CMD_CHAR_SET_STICK_DOWN = 419;
+export const CMD_CHAR_UPDATE_BIT_FILTER = 420;
 
 // Constraints 500-599
 

--- a/src/physics/jolt/front/body/component.mjs
+++ b/src/physics/jolt/front/body/component.mjs
@@ -52,11 +52,11 @@ class BodyComponent extends ShapeComponent {
     _group = 0;
 
     _inertiaMultiplier = 1;
-    
+
     _isSensor = false;
-    
+
     _linearDamping = 0;
-    
+
     _linearVelocity = new Vec3();
 
     _mask = 0;

--- a/src/physics/jolt/front/body/component.mjs
+++ b/src/physics/jolt/front/body/component.mjs
@@ -51,15 +51,15 @@ class BodyComponent extends ShapeComponent {
 
     _group = 0;
 
-    _mask = 0;
-
     _inertiaMultiplier = 1;
-
+    
     _isSensor = false;
-
+    
     _linearDamping = 0;
-
+    
     _linearVelocity = new Vec3();
+
+    _mask = 0;
 
     _maxAngularVelocity = 47.12388980384689;
 
@@ -429,6 +429,8 @@ class BodyComponent extends ShapeComponent {
     /**
      * Updates the filtering group bit. Value is ignored, if {@link JoltInitSettings.bitFiltering}
      * is not set.
+     *
+     * @param {number} group - Unsigned integer.
      */
     set group(group) {
         if (this._group === group) {
@@ -565,6 +567,8 @@ class BodyComponent extends ShapeComponent {
     /**
      * Updates the filtering mask bit. Value is ignored, if {@link JoltInitSettings.bitFiltering}
      * is not set.
+     *
+     * @param {number} mask - Unsigned integer.
      */
     set mask(mask) {
         if (this._mask === mask) {

--- a/src/physics/jolt/front/body/component.mjs
+++ b/src/physics/jolt/front/body/component.mjs
@@ -16,7 +16,8 @@ import {
     CMD_RESET_SLEEP_TIMER, CMD_SET_LIN_VEL_CLAMPED, CMD_SET_ANG_VEL_CLAMPED, CMD_RESET_MOTION,
     CMD_SET_MAX_ANG_VEL, CMD_SET_MAX_LIN_VEL, CMD_CLAMP_ANG_VEL, CMD_CLAMP_LIN_VEL,
     CMD_SET_VEL_STEPS, CMD_SET_POS_STEPS, CMD_ADD_ANGULAR_IMPULSE,
-    CMD_ADD_TORQUE
+    CMD_ADD_TORQUE,
+    CMD_UPDATE_BIT_FILTER
 } from '../../constants.mjs';
 
 const vec3 = new Vec3();
@@ -47,6 +48,10 @@ class BodyComponent extends ShapeComponent {
     _friction = 0.2;
 
     _gravityFactor = 1;
+
+    _group = 0;
+
+    _mask = 0;
 
     _inertiaMultiplier = 1;
 
@@ -422,6 +427,44 @@ class BodyComponent extends ShapeComponent {
     }
 
     /**
+     * Updates the filtering group bit. Value is ignored, if {@link JoltInitSettings.bitFiltering}
+     * is not set.
+     */
+    set group(group) {
+        if (this._group === group) {
+            return;
+        }
+
+        if ($_DEBUG) {
+            const ok = Debug.checkUint(group);
+            if (!ok) {
+                return;
+            }
+        }
+
+        this._group = group;
+        this.system.addCommand(
+            OPERATOR_MODIFIER, CMD_UPDATE_BIT_FILTER, this._index,
+            group, BUFFER_WRITE_UINT32, false,
+            this._mask, BUFFER_WRITE_UINT32, false
+        );
+    }
+
+    /**
+     * Collision group bit of an object layer.
+     *
+     * Two layers can collide if `object1.group` and `object2.mask` is non-zero and `object2.group`
+     * and `object1.mask` is non-zero. The behavior is similar to that of filtering in e.g. Bullet,
+     * Rapier.
+     *
+     * @returns {number} Unsigned integer.
+     * @defaultValue 0
+     */
+    get group() {
+        return this._group;
+    }
+
+    /**
      * When calculating the inertia the calculated inertia will be multiplied by this value. This
      * factor is ignored when {@link overrideMassProperties} is set to
      * `OMP_MASS_AND_INERTIA_PROVIDED` - you are expected to calculate inertia yourself in that
@@ -517,6 +560,44 @@ class BodyComponent extends ShapeComponent {
      */
     get linearVelocity() {
         return this._linearVelocity;
+    }
+
+    /**
+     * Updates the filtering mask bit. Value is ignored, if {@link JoltInitSettings.bitFiltering}
+     * is not set.
+     */
+    set mask(mask) {
+        if (this._mask === mask) {
+            return;
+        }
+
+        if ($_DEBUG) {
+            const ok = Debug.checkUint(mask);
+            if (!ok) {
+                return;
+            }
+        }
+
+        this._mask = mask;
+        this.system.addCommand(
+            OPERATOR_MODIFIER, CMD_UPDATE_BIT_FILTER, this._index,
+            this._group, BUFFER_WRITE_UINT32, false,
+            mask, BUFFER_WRITE_UINT32, false
+        );
+    }
+
+    /**
+     * Collision mask bit of an object layer.
+     *
+     * Two layers can collide if `object1.group` and `object2.mask` is non-zero and `object2.group`
+     * and `object1.mask` is non-zero. The behavior is similar to that of filtering in e.g. Bullet,
+     * Rapier.
+     *
+     * @returns {number} Unsigned integer.
+     * @defaultValue 0
+     */
+    get mask() {
+        return this._mask;
     }
 
     /**
@@ -655,8 +736,10 @@ class BodyComponent extends ShapeComponent {
     }
 
     /**
-     * Changes the object layer that this body belongs to. Allows cheap filtering. Following
-     * default aliases available:
+     * Changes the object layer that this body belongs to. Allows cheap filtering. Not used, if
+     * {@link JoltInitSettings.bitFiltering} is provided during system initialization.
+     *
+     * You can use the following pre-made ones:
      * ```
      * OBJ_LAYER_NON_MOVING
      * ```
@@ -1397,6 +1480,8 @@ class BodyComponent extends ShapeComponent {
 
         cb.write(this._motionType, BUFFER_WRITE_UINT8, false);
         cb.write(this._useMotionState, BUFFER_WRITE_BOOL, false);
+        cb.write(this._group, BUFFER_WRITE_UINT32, false);
+        cb.write(this._mask, BUFFER_WRITE_UINT32, false);
         cb.write(this._objectLayer, BUFFER_WRITE_UINT32, false);
         cb.write(this._linearVelocity, BUFFER_WRITE_VEC32, false);
         cb.write(this._angularVelocity, BUFFER_WRITE_VEC32, false);

--- a/src/physics/jolt/front/body/system.mjs
+++ b/src/physics/jolt/front/body/system.mjs
@@ -27,6 +27,8 @@ const schema = [
     'motionType',
     'objectLayer',
     'collisionGroup',
+    'group',
+    'mask',
     'subGroup',
     'allowedDOFs',
     'allowDynamicOrKinematic',

--- a/src/physics/jolt/front/char/system.mjs
+++ b/src/physics/jolt/front/char/system.mjs
@@ -34,6 +34,8 @@ const schema = [
     'pairedEntity',
     'bpFilterLayer',
     'objFilterLayer',
+    'group',
+    'mask',
     'stickToFloorStepDown',
     'walkStairsCosAngleForwardContact',
     'walkStairsMinStepForward',

--- a/src/physics/jolt/manager.mjs
+++ b/src/physics/jolt/manager.mjs
@@ -108,7 +108,8 @@ class JoltManager extends PhysicsManager {
         };
 
         // Make sure requested features are supported
-        config.useSharedArrayBuffer = config.useSharedArrayBuffer && typeof SharedArrayBuffer !== 'undefined';
+        config.useSharedArrayBuffer = config.useSharedArrayBuffer &&
+            typeof SharedArrayBuffer !== 'undefined';
         config.useWebWorker = config.useWebWorker && typeof Worker !== 'undefined';
         config.useSAB = config.useWebWorker && config.useSharedArrayBuffer;
 


### PR DESCRIPTION
PR adds an ability for an alternative object filtering using bit masks and groups, similar to Bullet physics.

```js
const GROUP_STATIC = 1;
const GROUP_FLOOR1 = 2;
const GROUP_FLOOR2 = 4;
const GROUP_FLOOR3 = 8;
const GROUP_ALL = GROUP_STATIC | GROUP_FLOOR1 | GROUP_FLOOR2 | GROUP_FLOOR3;

// init physics
await init(app, {
    fixedStep: 1 / 30,
    // ... other options,

    // Each pair in array is a broadphase layer: [included groups, excluded groups]
    bitFiltering: [
        GROUP_STATIC, 0,
        GROUP_FLOOR1 | GROUP_FLOOR2 | GROUP_FLOOR3, 0
    ]
});

// create floor that collides with everything
floorEntity.addComponent('body', {
    group: GROUP_STATIC,
    mask: GROUP_ALL
});

// create a dynamic body that collides with a floor GROUP_FLOOR2
dynamicEntity.addComponent('body', {
    group: GROUP_FLOOR2,
    mask: GROUP_ALL
});
```