### PR TITLE
Disable unit scale for mesh collider

### DIFF
--- a/src/physics/jolt/front/shape/component.mjs
+++ b/src/physics/jolt/front/shape/component.mjs
@@ -629,8 +629,7 @@ class ShapeComponent extends Component {
         const scale = props.scale || props.entity.getLocalScale();
         let useEntityScale = props.useEntityScale;
 
-        if (useEntityScale && scale.x === 1 && scale.y === 1 && scale.z === 1 &&
-            shape !== SHAPE_MESH && shape !== SHAPE_CONVEX_HULL) {
+        if (useEntityScale && scale.x === 1 && scale.y === 1 && scale.z === 1) {
             useEntityScale = false;
         }
 

--- a/src/physics/jolt/front/shape/component.mjs
+++ b/src/physics/jolt/front/shape/component.mjs
@@ -633,7 +633,6 @@ class ShapeComponent extends Component {
             useEntityScale = false;
         }
 
-        useEntityScale = useEntityScale || (shape === SHAPE_MESH || shape === SHAPE_CONVEX_HULL);
         cb.write(useEntityScale, BUFFER_WRITE_BOOL, false);
         if (useEntityScale) {
             // Potential precision loss 64 -> 32


### PR DESCRIPTION
Don't use a scaled shape for mesh/convex hull colliders, if scale is a unit vector.