### PR TITLE
Isometry update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@gamebop/physics",
     "description": "Physics components for PlayCanvas engine",
-    "version": "0.3.5",
+    "version": "0.4.0",
     "main": "dist/physics.min.mjs",
     "author": "Gamebop",
     "license": "MIT",

--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -9,9 +9,12 @@ import { Modifier } from './operators/modifier.mjs';
 import { Querier } from './operators/querier.mjs';
 import { Tracker } from './operators/tracker.mjs';
 import {
-    BP_LAYER_MOVING, BP_LAYER_NON_MOVING, BUFFER_WRITE_BOOL, BUFFER_WRITE_FLOAT32, BUFFER_WRITE_JOLTVEC32,
-    BUFFER_WRITE_UINT32, BUFFER_WRITE_UINT8, BUFFER_WRITE_VEC32, CMD_REPORT_TRANSFORMS, COMPONENT_SYSTEM_BODY,
-    COMPONENT_SYSTEM_CHAR, COMPONENT_SYSTEM_SOFT_BODY, GROUND_STATE_IN_AIR, GROUND_STATE_NOT_SUPPORTED, GROUND_STATE_ON_GROUND, GROUND_STATE_ON_STEEP_GROUND, OBJ_LAYER_MOVING, OBJ_LAYER_NON_MOVING, OPERATOR_CLEANER,
+    BP_LAYER_MOVING, BP_LAYER_NON_MOVING, BUFFER_WRITE_BOOL, BUFFER_WRITE_FLOAT32,
+    BUFFER_WRITE_JOLTVEC32, BUFFER_WRITE_UINT32, BUFFER_WRITE_UINT8, BUFFER_WRITE_VEC32,
+    CMD_REPORT_TRANSFORMS, COMPONENT_SYSTEM_BODY, COMPONENT_SYSTEM_CHAR,
+    COMPONENT_SYSTEM_SOFT_BODY, GROUND_STATE_IN_AIR, GROUND_STATE_NOT_SUPPORTED,
+    GROUND_STATE_ON_GROUND, GROUND_STATE_ON_STEEP_GROUND, ISOMETRY_FRONT_TO_BACK,
+    ISOMETRY_NONE, OBJ_LAYER_MOVING, OBJ_LAYER_NON_MOVING, OPERATOR_CLEANER,
     OPERATOR_CREATOR, OPERATOR_MODIFIER, OPERATOR_QUERIER
 } from '../constants.mjs';
 
@@ -768,10 +771,10 @@ class JoltBackend {
                 const bodyID = bodyList.at(i);
                 const body = system.GetBodyLockInterface().TryGetBody(bodyID);
 
-                if (!body.autoUpdateIsometry ||
-                        body.isCharPaired ||
-                        body.GetMotionType() !== Jolt.EMotionType_Dynamic ||
-                        Jolt.getPointer(body) === 0) {
+                if (Jolt.getPointer(body) === 0 ||
+                        body.isometryUpdate === ISOMETRY_FRONT_TO_BACK ||
+                        body.isometryUpdate === ISOMETRY_NONE ||
+                        body.isCharPaired) {
                     continue;
                 }
 

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -548,7 +548,7 @@ class Creator {
         const body = bodyInterface.CreateBody(bodyCreationSettings);
         bodyInterface.AddBody(body.GetID(), Jolt.EActivation_Activate);
 
-        body.autoUpdateIsometry = cb.read(BUFFER_READ_BOOL);
+        body.isometryUpdate = cb.read(BUFFER_READ_UINT8);
 
         if ($_DEBUG) {
             body.debugDrawDepth = cb.read(BUFFER_READ_BOOL);

--- a/src/physics/jolt/back/operators/modifier.mjs
+++ b/src/physics/jolt/back/operators/modifier.mjs
@@ -849,13 +849,13 @@ class Modifier {
 
     _setAutoUpdateIsometry(cb) {
         const body = this._getBody(cb);
-        const bool = cb.read(BUFFER_READ_BOOL);
+        const type = cb.read(BUFFER_READ_UINT8);
 
         if (!body) {
             return true;
         }
 
-        body.autoUpdateIsometry = bool;
+        body.isometryUpdate = type;
 
         return true;
     }

--- a/src/physics/jolt/constants.mjs
+++ b/src/physics/jolt/constants.mjs
@@ -18,6 +18,11 @@ export const DOF_ROTATION_Y = 16;
 export const DOF_ROTATION_Z = 32;
 export const DOF_ALL = 63;
 
+export const ISOMETRY_DEFAULT = 0;
+export const ISOMETRY_FRONT_TO_BACK = 1;
+export const ISOMETRY_BACK_TO_FRONT = 2;
+export const ISOMETRY_NONE = 3;
+
 export const OMP_CALCULATE_MASS_AND_INERTIA = 0;
 export const OMP_CALCULATE_INERTIA = 1;
 export const OMP_MASS_AND_INERTIA_PROVIDED = 2;

--- a/src/physics/jolt/front/body/system.mjs
+++ b/src/physics/jolt/front/body/system.mjs
@@ -21,6 +21,7 @@ const schema = [
     'maxAngularVelocity',
     'gravityFactor',
     'inertiaMultiplier',
+    'isometryUpdate',
     'overrideMass',
     'overrideMassProperties',
     'overrideInertiaPosition',
@@ -35,8 +36,7 @@ const schema = [
     'allowDynamicOrKinematic',
     'isSensor',
     'motionQuality',
-    'allowSleeping',
-    'autoUpdateIsometry'
+    'allowSleeping'
 ];
 
 /**


### PR DESCRIPTION
Removes old `body.autoUpdateIsometry` and adds `body.isometryUpdate`.

The previous boolean flag was not flexible enough. Instead, we now have a `body.isometryUpdate`, which allows a granular control over how the rendering frontend and physics backend synchronize the entity-body transforms.

`ISOMETRY_DEFAULT`: default behavior, front tells where kinematic bodies are, back says where entities linked to dynamic bodies are.
`ISOMETRY_FRONT_TO_BACK`: front will tell where the body is.
`ISOMETRY_BACK_TO_FRONT`: back will tell where the entity should be.
`ISOMETRY_NONE`: no automatic update.

```js
// create a kinematic body, but disable auto update its transforms every frame
entity.addComponent('body', {
    motionType: MOTION_TYPE_KINEMATIC,
    objectLayer: OBJ_LAYER_MOVING,
    isometryUpdate: ISOMETRY_NONE
});

// then when needed, move both - body and entity
entity.setPosition(newPosition);
entity.body.teleport(newPosition);
```