### PR TITLE
Disable update event on dynamic bodies

### DIFF
--- a/src/physics/jolt/front/body/component.mjs
+++ b/src/physics/jolt/front/body/component.mjs
@@ -733,6 +733,11 @@ class BodyComponent extends ShapeComponent {
             }
         }
 
+        if (type === MOTION_TYPE_DYNAMIC) {
+            this._isometryEvent?.off();
+            this._isometryEvent = null;
+        }
+
         this._motionType = type;
         this.system.addCommand(
             OPERATOR_MODIFIER, CMD_SET_MOTION_TYPE, this._index,


### PR DESCRIPTION
Disables possible update event when switching motion type to a dynamic body.