### PR TITLE
Immediate query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@gamebop/physics",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@gamebop/physics",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "license": "MIT",
             "devDependencies": {
                 "@babel/eslint-parser": "^7.25.1",
@@ -64,9 +64,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-            "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
+            "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -126,15 +126,15 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-            "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+            "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.26.2",
-                "@babel/types": "^7.26.0",
+                "@babel/parser": "^7.26.3",
+                "@babel/types": "^7.26.3",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^3.0.2"
@@ -244,14 +244,14 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-            "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+            "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/types": "^7.26.0"
+                "@babel/types": "^7.26.3"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -277,18 +277,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-            "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+            "version": "7.26.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+            "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/generator": "^7.25.9",
-                "@babel/parser": "^7.25.9",
+                "@babel/code-frame": "^7.26.2",
+                "@babel/generator": "^7.26.3",
+                "@babel/parser": "^7.26.3",
                 "@babel/template": "^7.25.9",
-                "@babel/types": "^7.25.9",
+                "@babel/types": "^7.26.3",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -308,9 +308,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-            "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+            "version": "7.26.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -380,13 +380,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-            "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
+            "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.4",
+                "@eslint/object-schema": "^2.1.5",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
@@ -395,19 +395,22 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-            "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
+            "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-            "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+            "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -442,9 +445,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.13.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.13.0.tgz",
-            "integrity": "sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==",
+            "version": "9.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
+            "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -452,9 +455,9 @@
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-            "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
+            "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -462,9 +465,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-            "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
+            "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -498,6 +501,20 @@
                 "node": ">=18.18.0"
             }
         },
+        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -513,9 +530,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+            "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -630,9 +647,9 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+            "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -748,9 +765,9 @@
             }
         },
         "node_modules/@playcanvas/eslint-config": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-2.0.6.tgz",
-            "integrity": "sha512-2BHPnEqGWMB57emZ2Z8o/324dbdItKf9810TcE+Onx/8aGssSN8un9EaP4Wic7YWoFC6yyH/FT7o96Q88D7UHA==",
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@playcanvas/eslint-config/-/eslint-config-2.0.8.tgz",
+            "integrity": "sha512-/bRWBdAScQfLUEkxYo22MhsfSOfNRW9zA0mjqdfFnpOsAmt1M6Ejlsp3I+bAeIMOj8Om20g4rBjlQtWxzow1Ag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -784,9 +801,9 @@
             }
         },
         "node_modules/@rollup/plugin-node-resolve": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.0.tgz",
-            "integrity": "sha512-9eO5McEICxMzJpDW9OnMYSv4Sta3hmt7VtBFz5zR9273suNOydOyq/FrGeGy+KsTRFm8w0SLVhzig2ILFT63Ag==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+            "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -855,9 +872,9 @@
             }
         },
         "node_modules/@rollup/pluginutils": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
-            "integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+            "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -878,9 +895,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.3.tgz",
-            "integrity": "sha512-ufb2CH2KfBWPJok95frEZZ82LtDl0A6QKTa8MoM+cWwDZvVGl5/jNb79pIhRvAalUu+7LD91VYR0nwRD799HkQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+            "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
             "cpu": [
                 "arm"
             ],
@@ -892,9 +909,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.3.tgz",
-            "integrity": "sha512-iAHpft/eQk9vkWIV5t22V77d90CRofgR2006UiCjHcHJFVI1E0oBkQIAbz+pLtthFw3hWEmVB4ilxGyBf48i2Q==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+            "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
             "cpu": [
                 "arm64"
             ],
@@ -906,9 +923,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.3.tgz",
-            "integrity": "sha512-QPW2YmkWLlvqmOa2OwrfqLJqkHm7kJCIMq9kOz40Zo9Ipi40kf9ONG5Sz76zszrmIZZ4hgRIkez69YnTHgEz1w==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+            "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
             "cpu": [
                 "arm64"
             ],
@@ -920,9 +937,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.3.tgz",
-            "integrity": "sha512-KO0pN5x3+uZm1ZXeIfDqwcvnQ9UEGN8JX5ufhmgH5Lz4ujjZMAnxQygZAVGemFWn+ZZC0FQopruV4lqmGMshow==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+            "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
             "cpu": [
                 "x64"
             ],
@@ -934,9 +951,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.24.3.tgz",
-            "integrity": "sha512-CsC+ZdIiZCZbBI+aRlWpYJMSWvVssPuWqrDy/zi9YfnatKKSLFCe6fjna1grHuo/nVaHG+kiglpRhyBQYRTK4A==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+            "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
             "cpu": [
                 "arm64"
             ],
@@ -948,9 +965,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.24.3.tgz",
-            "integrity": "sha512-F0nqiLThcfKvRQhZEzMIXOQG4EeX61im61VYL1jo4eBxv4aZRmpin6crnBJQ/nWnCsjH5F6J3W6Stdm0mBNqBg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+            "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
             "cpu": [
                 "x64"
             ],
@@ -962,9 +979,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.3.tgz",
-            "integrity": "sha512-KRSFHyE/RdxQ1CSeOIBVIAxStFC/hnBgVcaiCkQaVC+EYDtTe4X7z5tBkFyRoBgUGtB6Xg6t9t2kulnX6wJc6A==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+            "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
             "cpu": [
                 "arm"
             ],
@@ -976,9 +993,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.3.tgz",
-            "integrity": "sha512-h6Q8MT+e05zP5BxEKz0vi0DhthLdrNEnspdLzkoFqGwnmOzakEHSlXfVyA4HJ322QtFy7biUAVFPvIDEDQa6rw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+            "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
             "cpu": [
                 "arm"
             ],
@@ -990,9 +1007,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.3.tgz",
-            "integrity": "sha512-fKElSyXhXIJ9pqiYRqisfirIo2Z5pTTve5K438URf08fsypXrEkVmShkSfM8GJ1aUyvjakT+fn2W7Czlpd/0FQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+            "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
             "cpu": [
                 "arm64"
             ],
@@ -1004,9 +1021,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.3.tgz",
-            "integrity": "sha512-YlddZSUk8G0px9/+V9PVilVDC6ydMz7WquxozToozSnfFK6wa6ne1ATUjUvjin09jp34p84milxlY5ikueoenw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+            "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
             "cpu": [
                 "arm64"
             ],
@@ -1017,10 +1034,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+            "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.3.tgz",
-            "integrity": "sha512-yNaWw+GAO8JjVx3s3cMeG5Esz1cKVzz8PkTJSfYzE5u7A+NvGmbVFEHP+BikTIyYWuz0+DX9kaA3pH9Sqxp69g==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+            "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
             "cpu": [
                 "ppc64"
             ],
@@ -1032,9 +1063,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.3.tgz",
-            "integrity": "sha512-lWKNQfsbpv14ZCtM/HkjCTm4oWTKTfxPmr7iPfp3AHSqyoTz5AgLemYkWLwOBWc+XxBbrU9SCokZP0WlBZM9lA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+            "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1046,9 +1077,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.3.tgz",
-            "integrity": "sha512-HoojGXTC2CgCcq0Woc/dn12wQUlkNyfH0I1ABK4Ni9YXyFQa86Fkt2Q0nqgLfbhkyfQ6003i3qQk9pLh/SpAYw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+            "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
             "cpu": [
                 "s390x"
             ],
@@ -1060,9 +1091,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.3.tgz",
-            "integrity": "sha512-mnEOh4iE4USSccBOtcrjF5nj+5/zm6NcNhbSEfR3Ot0pxBwvEn5QVUXcuOwwPkapDtGZ6pT02xLoPaNv06w7KQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+            "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
             "cpu": [
                 "x64"
             ],
@@ -1074,9 +1105,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.3.tgz",
-            "integrity": "sha512-rMTzawBPimBQkG9NKpNHvquIUTQPzrnPxPbCY1Xt+mFkW7pshvyIS5kYgcf74goxXOQk0CP3EoOC1zcEezKXhw==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+            "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
             "cpu": [
                 "x64"
             ],
@@ -1088,9 +1119,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.3.tgz",
-            "integrity": "sha512-2lg1CE305xNvnH3SyiKwPVsTVLCg4TmNCF1z7PSHX2uZY2VbUpdkgAllVoISD7JO7zu+YynpWNSKAtOrX3AiuA==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+            "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
             "cpu": [
                 "arm64"
             ],
@@ -1102,9 +1133,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.3.tgz",
-            "integrity": "sha512-9SjYp1sPyxJsPWuhOCX6F4jUMXGbVVd5obVpoVEi8ClZqo52ViZewA6eFz85y8ezuOA+uJMP5A5zo6Oz4S5rVQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+            "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
             "cpu": [
                 "ia32"
             ],
@@ -1116,9 +1147,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.3.tgz",
-            "integrity": "sha512-HGZgRFFYrMrP3TJlq58nR1xy8zHKId25vhmm5S9jETEfDf6xybPxsavFTJaufe2zgOGYJBskGlj49CwtEuFhWQ==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+            "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
             "cpu": [
                 "x64"
             ],
@@ -1137,58 +1168,58 @@
             "license": "MIT"
         },
         "node_modules/@shikijs/core": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.22.2.tgz",
-            "integrity": "sha512-bvIQcd8BEeR1yFvOYv6HDiyta2FFVePbzeowf5pPS1avczrPK+cjmaxxh0nx5QzbON7+Sv0sQfQVciO7bN72sg==",
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.24.3.tgz",
+            "integrity": "sha512-VRcf4GYUIkxIchGM9DrapRcxtgojg4IWKUtX5EtW+4PJiGzF2xQqZSv27PJt+WLc18KT3CNLpNWow9JYV5n+Rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/engine-javascript": "1.22.2",
-                "@shikijs/engine-oniguruma": "1.22.2",
-                "@shikijs/types": "1.22.2",
-                "@shikijs/vscode-textmate": "^9.3.0",
+                "@shikijs/engine-javascript": "1.24.3",
+                "@shikijs/engine-oniguruma": "1.24.3",
+                "@shikijs/types": "1.24.3",
+                "@shikijs/vscode-textmate": "^9.3.1",
                 "@types/hast": "^3.0.4",
-                "hast-util-to-html": "^9.0.3"
+                "hast-util-to-html": "^9.0.4"
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.22.2.tgz",
-            "integrity": "sha512-iOvql09ql6m+3d1vtvP8fLCVCK7BQD1pJFmHIECsujB0V32BJ0Ab6hxk1ewVSMFA58FI0pR2Had9BKZdyQrxTw==",
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.24.3.tgz",
+            "integrity": "sha512-De8tNLvYjeK6V0Gb47jIH2M+OKkw+lWnSV1j3HVDFMlNIglmVcTMG2fASc29W0zuFbfEEwKjO8Fe4KYSO6Ce3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.22.2",
-                "@shikijs/vscode-textmate": "^9.3.0",
-                "oniguruma-to-js": "0.4.3"
+                "@shikijs/types": "1.24.3",
+                "@shikijs/vscode-textmate": "^9.3.1",
+                "oniguruma-to-es": "0.8.0"
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.22.2.tgz",
-            "integrity": "sha512-GIZPAGzQOy56mGvWMoZRPggn0dTlBf1gutV5TdceLCZlFNqWmuc7u+CzD0Gd9vQUTgLbrt0KLzz6FNprqYAxlA==",
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.3.tgz",
+            "integrity": "sha512-iNnx950gs/5Nk+zrp1LuF+S+L7SKEhn8k9eXgFYPGhVshKppsYwRmW8tpmAMvILIMSDfrgqZ0w+3xWVQB//1Xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.22.2",
-                "@shikijs/vscode-textmate": "^9.3.0"
+                "@shikijs/types": "1.24.3",
+                "@shikijs/vscode-textmate": "^9.3.1"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.22.2.tgz",
-            "integrity": "sha512-NCWDa6LGZqTuzjsGfXOBWfjS/fDIbDdmVDug+7ykVe1IKT4c1gakrvlfFYp5NhAXH/lyqLM8wsAPo5wNy73Feg==",
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.3.tgz",
+            "integrity": "sha512-FPMrJ69MNxhRtldRk69CghvaGlbbN3pKRuvko0zvbfa2dXp4pAngByToqS5OY5jvN8D7LKR4RJE8UvzlCOuViw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/vscode-textmate": "^9.3.0",
+                "@shikijs/vscode-textmate": "^9.3.1",
                 "@types/hast": "^3.0.4"
             }
         },
         "node_modules/@shikijs/vscode-textmate": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
-            "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+            "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
             "dev": true,
             "license": "MIT"
         },
@@ -1255,16 +1286,16 @@
             "peer": true
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
+            "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/@webgpu/types": {
-            "version": "0.1.49",
-            "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.49.tgz",
-            "integrity": "sha512-NMmS8/DofhH/IFeW+876XrHVWel+J/vdcFCHLDqeJgkH9x0DeiwjVd8LcBdaxdG/T7Rf8VUAYsA8X1efMzLjRQ==",
+            "version": "0.1.52",
+            "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.52.tgz",
+            "integrity": "sha512-eI883Nlag2hGIkhXxAnq8s4APpqXWuPL3Gbn2ghiU12UjLvfCbVqHK4XfXl3eLRTatqcMmeK7jws7IwWsGfbzw==",
             "license": "BSD-3-Clause",
             "peer": true
         },
@@ -1389,14 +1420,14 @@
             "license": "Python-2.0"
         },
         "node_modules/array-buffer-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-            "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.5",
-                "is-array-buffer": "^3.0.4"
+                "call-bound": "^1.0.3",
+                "is-array-buffer": "^3.0.5"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1448,16 +1479,16 @@
             }
         },
         "node_modules/array.prototype.flat": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-            "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+            "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "es-shim-unscopables": "^1.0.0"
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.5",
+                "es-shim-unscopables": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1467,16 +1498,16 @@
             }
         },
         "node_modules/array.prototype.flatmap": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-            "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+            "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "es-shim-unscopables": "^1.0.0"
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.5",
+                "es-shim-unscopables": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1486,20 +1517,19 @@
             }
         },
         "node_modules/arraybuffer.prototype.slice": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-            "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+            "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
-                "call-bind": "^1.0.5",
+                "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.22.3",
-                "es-errors": "^1.2.1",
-                "get-intrinsic": "^1.2.3",
-                "is-array-buffer": "^3.0.4",
-                "is-shared-array-buffer": "^1.0.2"
+                "es-abstract": "^1.23.5",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "is-array-buffer": "^3.0.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1586,9 +1616,9 @@
             "license": "ISC"
         },
         "node_modules/browserslist": {
-            "version": "4.24.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-            "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+            "version": "4.24.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+            "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
             "dev": true,
             "funding": [
                 {
@@ -1607,9 +1637,9 @@
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001669",
-                "electron-to-chromium": "^1.5.41",
-                "node-releases": "^2.0.18",
+                "caniuse-lite": "^1.0.30001688",
+                "electron-to-chromium": "^1.5.73",
+                "node-releases": "^2.0.19",
                 "update-browserslist-db": "^1.1.1"
             },
             "bin": {
@@ -1627,17 +1657,47 @@
             "license": "MIT"
         },
         "node_modules/call-bind": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "call-bind-apply-helpers": "^1.0.0",
                 "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
                 "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.1"
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+            "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "get-intrinsic": "^1.2.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1670,9 +1730,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001676",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001676.tgz",
-            "integrity": "sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==",
+            "version": "1.0.30001690",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+            "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
             "dev": true,
             "funding": [
                 {
@@ -1882,9 +1942,9 @@
             "peer": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1897,15 +1957,15 @@
             }
         },
         "node_modules/data-view-buffer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-            "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+            "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.6",
+                "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
+                "is-data-view": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -1915,31 +1975,31 @@
             }
         },
         "node_modules/data-view-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-            "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+            "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
+                "is-data-view": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "url": "https://github.com/sponsors/inspect-js"
             }
         },
         "node_modules/data-view-byte-offset": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-            "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+            "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.6",
+                "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
                 "is-data-view": "^1.0.1"
             },
@@ -1951,9 +2011,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2091,6 +2151,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2099,9 +2174,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.49",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.49.tgz",
-            "integrity": "sha512-ZXfs1Of8fDb6z7WEYZjXpgIRF6MEu8JdeGA0A40aZq6OQbS+eJpnnV49epZRna2DU/YsEjSQuGtQPPtvt6J65A==",
+            "version": "1.5.75",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.75.tgz",
+            "integrity": "sha512-Lf3++DumRE/QmweGjU+ZcKqQ+3bKkU/qjaKYhIJKEOhgIO9Xs6IiAQFkfFoj+RhgDk4LUeNsLo6plExHqSyu6Q==",
             "dev": true,
             "license": "ISC",
             "peer": true
@@ -2110,6 +2185,13 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/emoji-regex-xs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+            "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
             "dev": true,
             "license": "MIT"
         },
@@ -2127,58 +2209,60 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-            "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+            "version": "1.23.6",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.6.tgz",
+            "integrity": "sha512-Ifco6n3yj2tMZDWNLyloZrytt9lqqlwvS83P3HtaETR0NUOYnIULGGHpktqYGObGy+8wc1okO25p8TjemhImvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
-                "arraybuffer.prototype.slice": "^1.0.3",
+                "arraybuffer.prototype.slice": "^1.0.4",
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
                 "data-view-buffer": "^1.0.1",
                 "data-view-byte-length": "^1.0.1",
                 "data-view-byte-offset": "^1.0.0",
-                "es-define-property": "^1.0.0",
+                "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
                 "es-object-atoms": "^1.0.0",
                 "es-set-tostringtag": "^2.0.3",
-                "es-to-primitive": "^1.2.1",
-                "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.4",
+                "es-to-primitive": "^1.3.0",
+                "function.prototype.name": "^1.1.7",
+                "get-intrinsic": "^1.2.6",
                 "get-symbol-description": "^1.0.2",
-                "globalthis": "^1.0.3",
-                "gopd": "^1.0.1",
+                "globalthis": "^1.0.4",
+                "gopd": "^1.2.0",
                 "has-property-descriptors": "^1.0.2",
-                "has-proto": "^1.0.3",
-                "has-symbols": "^1.0.3",
+                "has-proto": "^1.2.0",
+                "has-symbols": "^1.1.0",
                 "hasown": "^2.0.2",
-                "internal-slot": "^1.0.7",
+                "internal-slot": "^1.1.0",
                 "is-array-buffer": "^3.0.4",
                 "is-callable": "^1.2.7",
-                "is-data-view": "^1.0.1",
+                "is-data-view": "^1.0.2",
                 "is-negative-zero": "^2.0.3",
-                "is-regex": "^1.1.4",
+                "is-regex": "^1.2.1",
                 "is-shared-array-buffer": "^1.0.3",
-                "is-string": "^1.0.7",
+                "is-string": "^1.1.1",
                 "is-typed-array": "^1.1.13",
-                "is-weakref": "^1.0.2",
-                "object-inspect": "^1.13.1",
+                "is-weakref": "^1.1.0",
+                "math-intrinsics": "^1.0.0",
+                "object-inspect": "^1.13.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.5",
-                "regexp.prototype.flags": "^1.5.2",
-                "safe-array-concat": "^1.1.2",
-                "safe-regex-test": "^1.0.3",
-                "string.prototype.trim": "^1.2.9",
-                "string.prototype.trimend": "^1.0.8",
+                "regexp.prototype.flags": "^1.5.3",
+                "safe-array-concat": "^1.1.3",
+                "safe-regex-test": "^1.1.0",
+                "string.prototype.trim": "^1.2.10",
+                "string.prototype.trimend": "^1.0.9",
                 "string.prototype.trimstart": "^1.0.8",
                 "typed-array-buffer": "^1.0.2",
                 "typed-array-byte-length": "^1.0.1",
-                "typed-array-byte-offset": "^1.0.2",
-                "typed-array-length": "^1.0.6",
+                "typed-array-byte-offset": "^1.0.3",
+                "typed-array-length": "^1.0.7",
                 "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.15"
+                "which-typed-array": "^1.1.16"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2188,14 +2272,11 @@
             }
         },
         "node_modules/es-define-property": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.2.4"
-            },
             "engines": {
                 "node": ">= 0.4"
             }
@@ -2256,15 +2337,15 @@
             }
         },
         "node_modules/es-to-primitive": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
+                "is-callable": "^1.2.7",
+                "is-date-object": "^1.0.5",
+                "is-symbol": "^1.0.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2297,32 +2378,32 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.13.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.13.0.tgz",
-            "integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
+            "version": "9.17.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
+            "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.11.0",
-                "@eslint/config-array": "^0.18.0",
-                "@eslint/core": "^0.7.0",
-                "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.13.0",
-                "@eslint/plugin-kit": "^0.2.0",
-                "@humanfs/node": "^0.16.5",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.19.0",
+                "@eslint/core": "^0.9.0",
+                "@eslint/eslintrc": "^3.2.0",
+                "@eslint/js": "9.17.0",
+                "@eslint/plugin-kit": "^0.2.3",
+                "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.3.1",
+                "@humanwhocodes/retry": "^0.4.1",
                 "@types/estree": "^1.0.6",
                 "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
+                "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.1.0",
-                "eslint-visitor-keys": "^4.1.0",
-                "espree": "^10.2.0",
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -2336,8 +2417,7 @@
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3",
-                "text-table": "^0.2.0"
+                "optionator": "^0.9.3"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
@@ -2452,9 +2532,9 @@
             }
         },
         "node_modules/eslint-plugin-jsdoc": {
-            "version": "50.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.4.3.tgz",
-            "integrity": "sha512-uWtwFxGRv6B8sU63HZM5dAGDhgsatb+LONwmILZJhdRALLOkCX2HFZhdL/Kw2ls8SQMAVEfK+LmnEfxInRN8HA==",
+            "version": "50.6.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.1.tgz",
+            "integrity": "sha512-UWyaYi6iURdSfdVVqvfOs2vdCVz0J40O/z/HTsv2sFjdjmdlUI/qlKLOTmwbPQ2tAfQnE5F9vqx+B+poF71DBQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -2491,14 +2571,14 @@
             }
         },
         "node_modules/eslint-plugin-regexp": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-2.6.0.tgz",
-            "integrity": "sha512-FCL851+kislsTEQEMioAlpDuK5+E5vs0hi1bF8cFlPlHcEjeRhuAzEsGikXRreE+0j4WhW2uO54MqTjXtYOi3A==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-2.7.0.tgz",
+            "integrity": "sha512-U8oZI77SBtH8U3ulZ05iu0qEzIizyEDXd+BWHvyVxTOjGwcDcvy/kEpgFG4DYca2ByRLiVPFZ2GeH7j1pdvZTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.9.1",
+                "@eslint-community/regexpp": "^4.11.0",
                 "comment-parser": "^1.4.0",
                 "jsdoc-type-pratt-parser": "^4.0.0",
                 "refa": "^0.12.1",
@@ -2769,9 +2849,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
             "dev": true,
             "license": "ISC"
         },
@@ -2835,16 +2915,18 @@
             }
         },
         "node_modules/function.prototype.name": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "functions-have-names": "^1.2.3"
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "functions-have-names": "^1.2.3",
+                "hasown": "^2.0.2",
+                "is-callable": "^1.2.7"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2885,17 +2967,22 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+            "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "dunder-proto": "^1.0.0",
+                "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
                 "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2905,15 +2992,15 @@
             }
         },
         "node_modules/get-symbol-description": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-            "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+            "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.5",
+                "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4"
+                "get-intrinsic": "^1.2.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2980,9 +3067,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "15.11.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-15.11.0.tgz",
-            "integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==",
+            "version": "15.14.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+            "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3010,24 +3097,27 @@
             }
         },
         "node_modules/gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-bigints": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -3056,11 +3146,14 @@
             }
         },
         "node_modules/has-proto": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+            "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.0"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -3069,9 +3162,9 @@
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3111,9 +3204,9 @@
             }
         },
         "node_modules/hast-util-to-html": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
-            "integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.4.tgz",
+            "integrity": "sha512-wxQzXtdbhiwGAUKrnQJXlOPmHnEehzphwkK7aluUPQ+lEc1xefC8pblMgpp2w5ldBTEfveRIrADcrhGIWrlTDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3262,29 +3355,46 @@
             "license": "ISC"
         },
         "node_modules/internal-slot": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-            "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "hasown": "^2.0.0",
-                "side-channel": "^1.0.4"
+                "hasown": "^2.0.2",
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/is-array-buffer": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-            "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1"
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-async-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
+            "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3294,13 +3404,16 @@
             }
         },
         "node_modules/is-bigint": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "has-bigints": "^1.0.1"
+                "has-bigints": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3320,14 +3433,14 @@
             }
         },
         "node_modules/is-boolean-object": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+            "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3350,9 +3463,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+            "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3366,12 +3479,14 @@
             }
         },
         "node_modules/is-data-view": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-            "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+            "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "call-bound": "^1.0.2",
+                "get-intrinsic": "^1.2.6",
                 "is-typed-array": "^1.1.13"
             },
             "engines": {
@@ -3382,13 +3497,14 @@
             }
         },
         "node_modules/is-date-object": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3407,6 +3523,22 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-finalizationregistry": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+            "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3415,6 +3547,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-glob": {
@@ -3428,6 +3576,19 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-module": {
@@ -3461,13 +3622,14 @@
             }
         },
         "node_modules/is-number-object": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3487,14 +3649,16 @@
             }
         },
         "node_modules/is-regex": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.2",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3503,14 +3667,27 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-set": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-shared-array-buffer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-            "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7"
+                "call-bound": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3520,13 +3697,14 @@
             }
         },
         "node_modules/is-string": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3536,13 +3714,15 @@
             }
         },
         "node_modules/is-symbol": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "has-symbols": "^1.0.2"
+                "call-bound": "^1.0.2",
+                "has-symbols": "^1.1.0",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3552,13 +3732,13 @@
             }
         },
         "node_modules/is-typed-array": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-            "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "which-typed-array": "^1.1.14"
+                "which-typed-array": "^1.1.16"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3580,14 +3760,47 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-weakmap": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-weakref": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+            "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2"
+                "call-bound": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakset": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3624,9 +3837,9 @@
             }
         },
         "node_modules/jolt-physics": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/jolt-physics/-/jolt-physics-0.28.0.tgz",
-            "integrity": "sha512-BUyDqrDbdqWbhzgDq30Opo+Vee/Jvs5M+ZPDoWuIksi1t62oTE6YdBVsAN/n+JmDd8YEn34BDLwSI6fXlFKh3Q==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/jolt-physics/-/jolt-physics-0.28.1.tgz",
+            "integrity": "sha512-LJMWmndP50SmAjpoRM4udWnTOX/CmJLqxZMvKqrqJUU1+Iq9z+bljSaGguaKm1NpPAndcSuCTkRphkRAVG3rgg==",
             "license": "MIT",
             "peer": true
         },
@@ -3689,9 +3902,9 @@
             }
         },
         "node_modules/jsesc": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -3837,9 +4050,9 @@
             "license": "MIT"
         },
         "node_modules/magic-string": {
-            "version": "0.30.12",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
-            "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3862,6 +4075,16 @@
             },
             "bin": {
                 "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/mdast-util-to-hast": {
@@ -3894,9 +4117,9 @@
             "license": "MIT"
         },
         "node_modules/micromark-util-character": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
-            "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "dev": true,
             "funding": [
                 {
@@ -3915,9 +4138,9 @@
             }
         },
         "node_modules/micromark-util-encode": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
-            "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
             "dev": true,
             "funding": [
                 {
@@ -3932,9 +4155,9 @@
             "license": "MIT"
         },
         "node_modules/micromark-util-sanitize-uri": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
-            "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
             "dev": true,
             "funding": [
                 {
@@ -3954,9 +4177,9 @@
             }
         },
         "node_modules/micromark-util-symbol": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
-            "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "dev": true,
             "funding": [
                 {
@@ -3971,9 +4194,9 @@
             "license": "MIT"
         },
         "node_modules/micromark-util-types": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
-            "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
+            "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
             "dev": true,
             "funding": [
                 {
@@ -4120,9 +4343,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -4180,9 +4403,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+            "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4203,15 +4426,17 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.5",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
                 "define-properties": "^1.2.1",
-                "has-symbols": "^1.0.3",
+                "es-object-atoms": "^1.0.0",
+                "has-symbols": "^1.1.0",
                 "object-keys": "^1.1.1"
             },
             "engines": {
@@ -4256,13 +4481,14 @@
             }
         },
         "node_modules/object.values": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
-            "integrity": "sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+            "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
                 "define-properties": "^1.2.1",
                 "es-object-atoms": "^1.0.0"
             },
@@ -4283,17 +4509,16 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/oniguruma-to-js": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz",
-            "integrity": "sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==",
+        "node_modules/oniguruma-to-es": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.8.0.tgz",
+            "integrity": "sha512-rY+/a6b+uCgoYIL9itjY0x99UUDHXmGaw7Jjk5ZvM/3cxDJifyxFr/Zm4tTmF6Tre18gAakJo7AzhKUeMNLgHA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "regex": "^4.3.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
+                "emoji-regex-xs": "^1.0.0",
+                "regex": "^5.0.2",
+                "regex-recursion": "^5.0.0"
             }
         },
         "node_modules/optionator": {
@@ -4472,9 +4697,9 @@
             }
         },
         "node_modules/playcanvas": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.2.1.tgz",
-            "integrity": "sha512-K56A1T7AaQlHNiCmKk2KXnV12H/FCE51TXETPc6RlhMRDjS85nqs/lP6NVrTTg287oJRp6DtOvhoStgkHJMzFA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/playcanvas/-/playcanvas-2.3.3.tgz",
+            "integrity": "sha512-0Lzq5wJliAQ9NmU//pK6HPW/S3x95/z4Z/cOpPcX0qYbePESUyZupcViOVsclXW0SEKBnEzRjNuWAtgMw1kraA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -4606,10 +4831,53 @@
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
+        "node_modules/reflect.getprototypeof": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.9.tgz",
+            "integrity": "sha512-r0Ay04Snci87djAsI4U+WNRcSw5S4pOH7qFjd/veA5gC7TbqESR3tcj28ia95L/fYUDw11JKP7uqUKUAfVvV5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "dunder-proto": "^1.0.1",
+                "es-abstract": "^1.23.6",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "gopd": "^1.2.0",
+                "which-builtin-type": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/regex": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/regex/-/regex-4.3.3.tgz",
-            "integrity": "sha512-r/AadFO7owAq1QJVeZ/nq9jNS1vyZt+6t1p/E59B56Rn2GCya+gr1KSyOzNL/er+r+B7phv5jG2xU2Nz1YkmJg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-5.0.2.tgz",
+            "integrity": "sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-recursion": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.0.0.tgz",
+            "integrity": "sha512-UwyOqeobrCCqTXPcsSqH4gDhOjD5cI/b8kjngWgSZbxYh5yVjAwTjO5+hAuPRNiuR70+5RlWSs+U9PVcVcW9Lw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-utilities": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+            "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
             "dev": true,
             "license": "MIT"
         },
@@ -4657,18 +4925,21 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "version": "1.22.10",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.13.0",
+                "is-core-module": "^2.16.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
             "bin": {
                 "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4748,9 +5019,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.24.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.3.tgz",
-            "integrity": "sha512-HBW896xR5HGmoksbi3JBDtmVzWiPAYqp7wip50hjQ67JbDz61nyoMPdqu1DvVW9asYb2M65Z20ZHsyJCMqMyDg==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+            "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4764,24 +5035,25 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.24.3",
-                "@rollup/rollup-android-arm64": "4.24.3",
-                "@rollup/rollup-darwin-arm64": "4.24.3",
-                "@rollup/rollup-darwin-x64": "4.24.3",
-                "@rollup/rollup-freebsd-arm64": "4.24.3",
-                "@rollup/rollup-freebsd-x64": "4.24.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.24.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.24.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.24.3",
-                "@rollup/rollup-linux-arm64-musl": "4.24.3",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.24.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.24.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.24.3",
-                "@rollup/rollup-linux-x64-gnu": "4.24.3",
-                "@rollup/rollup-linux-x64-musl": "4.24.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.24.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.24.3",
-                "@rollup/rollup-win32-x64-msvc": "4.24.3",
+                "@rollup/rollup-android-arm-eabi": "4.28.1",
+                "@rollup/rollup-android-arm64": "4.28.1",
+                "@rollup/rollup-darwin-arm64": "4.28.1",
+                "@rollup/rollup-darwin-x64": "4.28.1",
+                "@rollup/rollup-freebsd-arm64": "4.28.1",
+                "@rollup/rollup-freebsd-x64": "4.28.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+                "@rollup/rollup-linux-arm64-musl": "4.28.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+                "@rollup/rollup-linux-x64-gnu": "4.28.1",
+                "@rollup/rollup-linux-x64-musl": "4.28.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+                "@rollup/rollup-win32-x64-msvc": "4.28.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -4834,15 +5106,16 @@
             }
         },
         "node_modules/safe-array-concat": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-            "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+            "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "get-intrinsic": "^1.2.4",
-                "has-symbols": "^1.0.3",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
+                "get-intrinsic": "^1.2.6",
+                "has-symbols": "^1.1.0",
                 "isarray": "^2.0.5"
             },
             "engines": {
@@ -4874,15 +5147,15 @@
             "license": "MIT"
         },
         "node_modules/safe-regex-test": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-            "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.6",
+                "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
-                "is-regex": "^1.1.4"
+                "is-regex": "^1.2.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4984,31 +5257,88 @@
             }
         },
         "node_modules/shiki": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.22.2.tgz",
-            "integrity": "sha512-3IZau0NdGKXhH2bBlUk4w1IHNxPh6A5B2sUpyY+8utLu2j/h1QpFkAaUA1bAMxOWWGtTWcAh531vnS4NJKS/lA==",
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.24.3.tgz",
+            "integrity": "sha512-eMeX/ehE2IDKVs71kB4zVcDHjutNcOtm+yIRuR4sA6ThBbdFI0DffGJiyoKCodj0xRGxIoWC3pk/Anmm5mzHmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "1.22.2",
-                "@shikijs/engine-javascript": "1.22.2",
-                "@shikijs/engine-oniguruma": "1.22.2",
-                "@shikijs/types": "1.22.2",
-                "@shikijs/vscode-textmate": "^9.3.0",
+                "@shikijs/core": "1.24.3",
+                "@shikijs/engine-javascript": "1.24.3",
+                "@shikijs/engine-oniguruma": "1.24.3",
+                "@shikijs/types": "1.24.3",
+                "@shikijs/vscode-textmate": "^9.3.1",
                 "@types/hast": "^3.0.4"
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
                 "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4",
-                "object-inspect": "^1.13.1"
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5151,16 +5481,19 @@
             }
         },
         "node_modules/string.prototype.trim": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-            "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+            "version": "1.2.10",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+            "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
+                "define-data-property": "^1.1.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.0",
-                "es-object-atoms": "^1.0.0"
+                "es-abstract": "^1.23.5",
+                "es-object-atoms": "^1.0.0",
+                "has-property-descriptors": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5170,15 +5503,19 @@
             }
         },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-            "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+            "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
                 "define-properties": "^1.2.1",
                 "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5311,9 +5648,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.36.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
-            "integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
+            "version": "5.37.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+            "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -5328,13 +5665,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -5387,9 +5717,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-            "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
         },
@@ -5407,32 +5737,32 @@
             }
         },
         "node_modules/typed-array-buffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-            "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
-                "is-typed-array": "^1.1.13"
+                "is-typed-array": "^1.1.14"
             },
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/typed-array-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-            "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+            "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
                 "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13"
+                "gopd": "^1.2.0",
+                "has-proto": "^1.2.0",
+                "is-typed-array": "^1.1.14"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5442,18 +5772,19 @@
             }
         },
         "node_modules/typed-array-byte-offset": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
-            "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+            "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
                 "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13"
+                "gopd": "^1.2.0",
+                "has-proto": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "reflect.getprototypeof": "^1.0.9"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5463,18 +5794,18 @@
             }
         },
         "node_modules/typed-array-length": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
-            "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+            "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
                 "is-typed-array": "^1.1.13",
-                "possible-typed-array-names": "^1.0.0"
+                "possible-typed-array-names": "^1.0.0",
+                "reflect.getprototypeof": "^1.0.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5484,9 +5815,9 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.26.10",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.10.tgz",
-            "integrity": "sha512-xLmVKJ8S21t+JeuQLNueebEuTVphx6IrP06CdV7+0WVflUSW3SPmR+h1fnWVdAR/FQePEgsSWCUHXqKKjzuUAw==",
+            "version": "0.26.11",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.11.tgz",
+            "integrity": "sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -5554,16 +5885,19 @@
             "license": "MIT"
         },
         "node_modules/unbox-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+            "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
+                "call-bound": "^1.0.3",
                 "has-bigints": "^1.0.2",
-                "has-symbols": "^1.0.3",
-                "which-boxed-primitive": "^1.0.2"
+                "has-symbols": "^1.1.0",
+                "which-boxed-primitive": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5731,33 +6065,84 @@
             }
         },
         "node_modules/which-boxed-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-bigint": "^1.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
-                "is-symbol": "^1.0.3"
+                "is-bigint": "^1.1.0",
+                "is-boolean-object": "^1.2.1",
+                "is-number-object": "^1.1.1",
+                "is-string": "^1.1.1",
+                "is-symbol": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-builtin-type": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+            "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "function.prototype.name": "^1.1.6",
+                "has-tostringtag": "^1.0.2",
+                "is-async-function": "^2.0.0",
+                "is-date-object": "^1.1.0",
+                "is-finalizationregistry": "^1.1.0",
+                "is-generator-function": "^1.0.10",
+                "is-regex": "^1.2.1",
+                "is-weakref": "^1.0.2",
+                "isarray": "^2.0.5",
+                "which-boxed-primitive": "^1.1.0",
+                "which-collection": "^1.0.2",
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-collection": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-map": "^2.0.3",
+                "is-set": "^2.0.3",
+                "is-weakmap": "^2.0.2",
+                "is-weakset": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-            "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+            "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
                 "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
+                "gopd": "^1.2.0",
                 "has-tostringtag": "^1.0.2"
             },
             "engines": {
@@ -5847,9 +6232,9 @@
             "peer": true
         },
         "node_modules/yaml": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-            "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+            "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
             "dev": true,
             "license": "ISC",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@gamebop/physics",
     "description": "Physics components for PlayCanvas engine",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "main": "dist/physics.min.mjs",
     "author": "Gamebop",
     "license": "MIT",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -8,6 +8,7 @@
 export { JoltManager } from './physics/jolt/manager.mjs';
 export * from './physics/jolt/interfaces/settings.mjs';
 export * from './physics/jolt/interfaces/query-results.mjs';
+export { CastResult } from './physics/jolt/front/response-handler.mjs';
 
 export { ShapeComponent } from './physics/jolt/front/shape/component.mjs';
 export { ShapeComponentSystem } from './physics/jolt/front/shape/system.mjs';

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -8,7 +8,7 @@
 export { JoltManager } from './physics/jolt/manager.mjs';
 export * from './physics/jolt/interfaces/settings.mjs';
 export * from './physics/jolt/interfaces/query-results.mjs';
-export { CastResult } from './physics/jolt/front/response-handler.mjs';
+export { CastResult, CollideShapeResult } from './physics/jolt/front/response-handler.mjs';
 
 export { ShapeComponent } from './physics/jolt/front/shape/component.mjs';
 export { ShapeComponentSystem } from './physics/jolt/front/shape/system.mjs';
@@ -48,11 +48,5 @@ export { IndexedCache } from './physics/indexed-cache.mjs';
 
 export * from './physics/jolt/front/constraint/types/settings.mjs';
 export * from './physics/jolt/constants.mjs';
-
-export { JoltBackend } from './physics/jolt/back/backend.mjs';
-export { Querier } from './physics/jolt/back/operators/querier.mjs';
-export { Creator } from './physics/jolt/back/operators/creator.mjs';
-export { Listener } from './physics/jolt/back/operators/listener.mjs';
-export { Tracker } from './physics/jolt/back/operators/tracker.mjs';
 
 export { init, JoltInitSettings } from './physics/init.mjs';

--- a/src/physics/dispatcher.mjs
+++ b/src/physics/dispatcher.mjs
@@ -49,6 +49,10 @@ class Dispatcher {
         }
     }
 
+    immediateExecution(buffer) {
+        return Dispatcher.backend?.immediateExecution(buffer);
+    }
+
     destroy() {
         this._destroying = true;
 
@@ -68,6 +72,14 @@ class Dispatcher {
                 self.postMessage(msg);
             }
         }
+    }
+
+    immediateResponse(buffer) {
+        if (!this._useMainThread) {
+            return;
+        }
+
+        return this._manager.processImmediateBuffer(buffer);
     }
 }
 

--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -629,7 +629,7 @@ class JoltBackend {
 
             case OPERATOR_MODIFIER:
                 return this._modifier.immediateModify(cb);
-            
+
             default:
                 if ($_DEBUG) {
                     Debug.error(`Invalid operator: ${operator}`);

--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -277,7 +277,7 @@ class JoltBackend {
         outBuffer.init();
         outBuffer.reset();
 
-        return this._immediateQuery(cb);
+        return this._immediateCommand(cb);
     }
 
     immediateResponse() {
@@ -614,12 +614,27 @@ class JoltBackend {
         return ok;
     }
 
-    _immediateQuery(cb, meshBuffers) {
+    _immediateCommand(cb, meshBuffers) {
         const operator = cb.readOperator();
-        if (operator === OPERATOR_QUERIER) {
-            return this._querier.immediateQuery(cb);
-        } else if ($_DEBUG) {
-            Debug.error(`Invalid operator: ${operator}`);
+
+        switch (operator) {
+            case OPERATOR_QUERIER:
+                return this._querier.immediateQuery(cb);
+
+            case OPERATOR_CREATOR:
+                return this._creator.immediateCreate(cb);
+
+            case OPERATOR_CLEANER:
+                return this._cleaner.immediateClean(cb);
+
+            case OPERATOR_MODIFIER:
+                return this._modifier.immediateModify(cb);
+            
+            default:
+                if ($_DEBUG) {
+                    Debug.error(`Invalid operator: ${operator}`);
+                }
+                break;
         }
     }
 

--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -21,8 +21,8 @@ import {
 /**
  * Jolt Backend.
  *
- * @group Private
- * @private
+ * @group Managers
+ * @category Jolt
  */
 class JoltBackend {
     constructor(messenger, data) {

--- a/src/physics/jolt/back/operators/cleaner.mjs
+++ b/src/physics/jolt/back/operators/cleaner.mjs
@@ -3,10 +3,6 @@ import {
     BUFFER_READ_UINT32, CMD_DESTROY_BODY, CMD_DESTROY_CONSTRAINT, CMD_DESTROY_SHAPE
 } from '../../constants.mjs';
 
-/**
- * @group Private
- * @private
- */
 class Cleaner {
     static cleanDebugDrawData(body, Jolt) {
         if (body.debugDrawData) {

--- a/src/physics/jolt/back/operators/cleaner.mjs
+++ b/src/physics/jolt/back/operators/cleaner.mjs
@@ -42,6 +42,16 @@ class Cleaner {
         return ok;
     }
 
+    immediateClean(cb) {
+        const command = cb.readCommand();
+
+        if (command === CMD_DESTROY_SHAPE) {
+            this._destroyShape(cb);
+        } else if ($_DEBUG) {
+            Debug.warn('Command not recognized.');
+        }
+    }
+
     destroy() {
         this._backend = null;
     }

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -280,7 +280,7 @@ class Creator {
             case CMD_CREATE_GROUPS:
                 this._createGroups(cb);
                 break;
-            
+
             default:
                 if ($_DEBUG) {
                     Debug.error(`Invalid command: ${command}`);

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -15,10 +15,6 @@ import {
 } from '../../constants.mjs';
 import { ConstraintCreator } from './helpers/constraint-creator.mjs';
 
-/**
- * @group Private
- * @private
- */
 class Creator {
     static createShapeSettings(cb, meshBuffers, Jolt, jv, jq) {
         const shapeType = cb.read(BUFFER_READ_UINT8);

--- a/src/physics/jolt/back/operators/creator.mjs
+++ b/src/physics/jolt/back/operators/creator.mjs
@@ -273,6 +273,26 @@ class Creator {
         return ok;
     }
 
+    immediateCreate(cb, meshBuffers) {
+        const command = cb.readCommand();
+
+        switch (command) {
+            case CMD_CREATE_SHAPE:
+                this._createShape(cb, meshBuffers);
+                break;
+
+            case CMD_CREATE_GROUPS:
+                this._createGroups(cb);
+                break;
+            
+            default:
+                if ($_DEBUG) {
+                    Debug.error(`Invalid command: ${command}`);
+                }
+                break;
+        }
+    }
+
     createPhysicsSystem() {
         const backend = this._backend;
         const config = backend.config;

--- a/src/physics/jolt/back/operators/listener.mjs
+++ b/src/physics/jolt/back/operators/listener.mjs
@@ -6,10 +6,6 @@ import {
 
 const eval2 = eval;
 
-/**
- * @group Private
- * @private
- */
 class Listener {
     constructor(backend) {
         this._listener = null;

--- a/src/physics/jolt/back/operators/modifier.mjs
+++ b/src/physics/jolt/back/operators/modifier.mjs
@@ -257,6 +257,16 @@ class Modifier {
         return ok;
     }
 
+    immediateModify(cb) {
+        const command = cb.readCommand();
+
+        if (command === CMD_TOGGLE_GROUP_PAIR) {
+            this._toggleGroupPair(cb);
+        } else if ($_DEBUG) {
+            Debug.warn('Command not recognized');
+        }
+    }
+
     destroy() {
         const Jolt = this._backend.Jolt;
 

--- a/src/physics/jolt/back/operators/querier.mjs
+++ b/src/physics/jolt/back/operators/querier.mjs
@@ -53,10 +53,6 @@ function writeCollideShapeHit(cb, system, tracker, calculateNormal, hit, Jolt) {
 let collidePointResult;
 let params = [];
 
-/**
- * @group Private
- * @private
- */
 class Querier {
     constructor(backend) {
         this._backend = backend;

--- a/src/physics/jolt/back/operators/querier.mjs
+++ b/src/physics/jolt/back/operators/querier.mjs
@@ -188,6 +188,8 @@ class Querier {
         this._commandsBuffer.destroy();
         this._commandsBuffer = null;
 
+        collidePointResult = null;
+
         params.length = 0;
         params = undefined;
     }
@@ -208,6 +210,8 @@ class Querier {
 
         const queryIndex = cb.read(BUFFER_READ_INT32);
         buffer.write(queryIndex, BUFFER_WRITE_INT32, false);
+
+        const useImmediate = cb.read(BUFFER_READ_BOOL);
 
         try {
             jv.FromBuffer(cb);
@@ -275,6 +279,10 @@ class Querier {
                 Debug.error(e);
             }
             return false;
+        }
+
+        if (useImmediate) {
+            return buffer;
         }
 
         return true;
@@ -425,6 +433,8 @@ class Querier {
         const queryIndex = cb.read(BUFFER_READ_INT32);
         buffer.write(queryIndex, BUFFER_WRITE_INT32, false);
 
+        const useImmediate = cb.read(BUFFER_READ_BOOL);
+
         if (!collidePointResult) {
             collidePointResult = [];
         }
@@ -484,6 +494,10 @@ class Querier {
         buffer.write(count, BUFFER_WRITE_UINT16, false);
         for (let i = 0; i < count; i++) {
             buffer.write(collidePointResult[i], BUFFER_WRITE_UINT32, false);
+        }
+
+        if (useImmediate) {
+            return buffer;
         }
 
         return true;

--- a/src/physics/jolt/back/operators/tracker.mjs
+++ b/src/physics/jolt/back/operators/tracker.mjs
@@ -1,7 +1,3 @@
-/**
- * @group Private
- * @private
- */
 class Tracker {
     constructor(Jolt) {
         this._Jolt = Jolt;

--- a/src/physics/jolt/front/response-handler.mjs
+++ b/src/physics/jolt/front/response-handler.mjs
@@ -10,7 +10,6 @@ const emptyResult = [];
 
 /**
  * @import {Entity} from 'playcanvas'
- * @import {Vec3} from 'playcanvas'
  */
 
 class ContactResult {
@@ -37,11 +36,41 @@ class CharContactResult {
 
 /**
  * @interface
- * @param {Entity} entity - Entity that query has detected.
- * @param {Vec3} point - A point in world space where the contact was detected.
- * @param {number} fraction - A normalized fraction of the ray length.
+ * @group Managers
+ * @category Utilities
  */
 class CastResult {
+    /**
+     * Entity that the cast has detected.
+     *
+     * @type {Entity}
+     */
+    entity;
+
+    /**
+     * Cast result world point.
+     *
+     * @type {Vec3}
+     */
+    point;
+
+    /**
+     * Contact fraction. This is a normalized length (0-1 range) along the cast's path from start
+     * to end where the contact has been detected.
+     *
+     * @type {number}
+     */
+    number;
+
+    /**
+     * Contact normal will be included only if the query options requested to calculate contact
+     * normal. Otherwise it will be `null` (default).
+     *
+     * @type {null | Vec3}
+     */
+    normal = null;
+
+    /** @hideconstructor */
     constructor(entity, point, fraction, normal) {
         this.entity = entity;
         this.point = point;

--- a/src/physics/jolt/front/response-handler.mjs
+++ b/src/physics/jolt/front/response-handler.mjs
@@ -247,7 +247,7 @@ class ResponseHandler {
     }
 
     static handleCollidePointQuery(cb, queryMap) {
-        const queryIndex = cb.read(BUFFER_READ_UINT16);
+        const queryIndex = cb.read(BUFFER_READ_INT32);
         const hitsCount = cb.read(BUFFER_READ_UINT16);
 
         let result = emptyResult;
@@ -266,13 +266,17 @@ class ResponseHandler {
             result.push(entity);
         }
 
-        const callback = queryMap.get(queryIndex);
-        queryMap.free(queryIndex);
-        callback?.(result);
+        if (queryIndex >= 0) {
+            const callback = queryMap.get(queryIndex);
+            queryMap.free(queryIndex);
+            callback?.(result);
+        }
+
+        return result;
     }
 
     static handleCollideShapeQuery(cb, queryMap) {
-        const queryIndex = cb.read(BUFFER_READ_UINT16);
+        const queryIndex = cb.read(BUFFER_READ_INT32);
         const firstOnly = cb.read(BUFFER_READ_BOOL);
         const hitsCount = cb.read(BUFFER_READ_UINT16);
 
@@ -326,9 +330,13 @@ class ResponseHandler {
             }
         }
 
-        const callback = queryMap.get(queryIndex);
-        queryMap.free(queryIndex);
-        callback?.(result);
+        if (queryIndex >= 0) {
+            const callback = queryMap.get(queryIndex);
+            queryMap.free(queryIndex);
+            callback?.(result);
+        }
+
+        return result;
     }
 
     static handleCharCallback(cb, queryMap) {

--- a/src/physics/jolt/front/response-handler.mjs
+++ b/src/physics/jolt/front/response-handler.mjs
@@ -60,17 +60,23 @@ class CastResult {
      *
      * @type {number}
      */
-    number;
+    fraction;
 
     /**
      * Contact normal will be included only if the query options requested to calculate contact
      * normal. Otherwise it will be `null` (default).
      *
-     * @type {null | Vec3}
+     * @type {Vec3 | null}
      */
     normal = null;
 
-    /** @hideconstructor */
+    /**
+     * @hideconstructor
+     * @param {Entity} entity - Entity that query detected.
+     * @param {Vec3} point - Contact point.
+     * @param {number} fraction - Contact fraction.
+     * @param {Vec3} [normal] - Contact normal.
+     */
     constructor(entity, point, fraction, normal) {
         this.entity = entity;
         this.point = point;

--- a/src/physics/jolt/front/response-handler.mjs
+++ b/src/physics/jolt/front/response-handler.mjs
@@ -80,7 +80,11 @@ class CastResult {
         }
     }
 }
-
+/**
+ * @interface
+ * @group Managers
+ * @category Utilities
+ */
 class CollideShapeResult {
     constructor(entity, point1, point2, axis, depth, normal) {
         this.entity = entity;
@@ -378,4 +382,4 @@ class ResponseHandler {
     }
 }
 
-export { ResponseHandler, CastResult };
+export { ResponseHandler, CastResult, CollideShapeResult };

--- a/src/physics/jolt/front/response-handler.mjs
+++ b/src/physics/jolt/front/response-handler.mjs
@@ -1,7 +1,7 @@
 import { Vec3 } from 'playcanvas';
 import { ShapeComponentSystem } from './shape/system.mjs';
 import {
-    BUFFER_READ_BOOL, BUFFER_READ_FLOAT32, BUFFER_READ_UINT16, BUFFER_READ_UINT32,
+    BUFFER_READ_BOOL, BUFFER_READ_FLOAT32, BUFFER_READ_INT32, BUFFER_READ_UINT16, BUFFER_READ_UINT32,
     BUFFER_READ_UINT8, CONTACT_TYPE_ADDED, CONTACT_TYPE_PERSISTED, CONTACT_TYPE_REMOVED, FLOAT32_SIZE, UINT8_SIZE
 } from '../constants.mjs';
 import { fromBuffer } from '../math.mjs';
@@ -192,7 +192,7 @@ class ResponseHandler {
     }
 
     static handleCastQuery(cb, queryMap) {
-        const queryIndex = cb.read(BUFFER_READ_UINT16);
+        const queryIndex = cb.read(BUFFER_READ_INT32);
         const hitsCount = cb.read(BUFFER_READ_UINT16);
 
         let result = emptyResult;
@@ -237,9 +237,13 @@ class ResponseHandler {
             result.push(r);
         }
 
-        const callback = queryMap.get(queryIndex);
-        queryMap.free(queryIndex);
-        callback?.(result);
+        if (queryIndex >= 0) {
+            const callback = queryMap.get(queryIndex);
+            queryMap.free(queryIndex);
+            callback?.(result);
+        }
+
+        return result;
     }
 
     static handleCollidePointQuery(cb, queryMap) {

--- a/src/physics/jolt/interfaces/query-results.mjs
+++ b/src/physics/jolt/interfaces/query-results.mjs
@@ -1,5 +1,6 @@
 /**
- * @import {CastResult} from "../front/response-handler.mjs"
+ * @import { CastResult, CollideShapeResult } from "../front/response-handler.mjs"
+ * @import { Entity } from "playcanvas"
  */
 
 /**
@@ -11,10 +12,24 @@ function CastCallback(results) {}
 
 /**
  * @interface
+ * @param {Entity[]} results - An array of entities that the point collided with. Array will be
+ * empty, if no entities collided.
+ */
+function CollidePointCallback(results) {}
+
+/**
+ * @interface
+ * @param {CollideShapeResult[]} results - An array with query results. An empty array if no
+ * results.
+ */
+function CollideShapeCallback(results) {}
+
+/**
+ * @interface
  * @param {boolean} wasSet - Boolean, whether the shape was successfully changed or not. If there
  * is not enough physical space to create the shape, the shape change will fail and this will be
  * `false`.
  */
 function CharSetShapeCallback(wasSet) {}
 
-export { CastCallback, CharSetShapeCallback };
+export { CastCallback, CharSetShapeCallback, CollidePointCallback, CollideShapeCallback };

--- a/src/physics/jolt/interfaces/query-results.mjs
+++ b/src/physics/jolt/interfaces/query-results.mjs
@@ -7,7 +7,7 @@
  * @param {CastResult[]} results - An array with query results. An empty array if no
  * results.
  */
-function CastShapeCallback(results) {}
+function CastCallback(results) {}
 
 /**
  * @interface
@@ -17,4 +17,4 @@ function CastShapeCallback(results) {}
  */
 function CharSetShapeCallback(wasSet) {}
 
-export { CastShapeCallback, CharSetShapeCallback };
+export { CastCallback, CharSetShapeCallback };

--- a/src/physics/jolt/interfaces/settings.mjs
+++ b/src/physics/jolt/interfaces/settings.mjs
@@ -3,7 +3,23 @@
  * @group Managers
  * @category Utilities
  */
-class QuerySettings {
+class ImmediateSettings {
+    /**
+     * Whether to make a query and return the results immediately. Only supported when physics
+     * is running on main thread.
+     *
+     * @type {boolean}
+     * @defaultValue true
+     */
+    immediate;
+}
+
+/**
+ * @interface
+ * @group Managers
+ * @category Utilities
+ */
+class QuerySettings extends ImmediateSettings {
     /**
      * If `true`, the ray will ignore sensors.
      *
@@ -27,15 +43,6 @@ class QuerySettings {
      * @defaultValue OBJ_LAYER_MOVING (1)
      */
     objFilterLayer;
-
-    /**
-     * Whether to make a query and return the results immediately. Only supported when physics
-     * is running on main thread.
-     *
-     * @type {boolean}
-     * @defaultValue true
-     */
-    immediate;
 }
 
 /**
@@ -211,14 +218,18 @@ class ShapeSettings {
     density;
 
     /**
-     * @see {@link ShapeComponent.shapePosition}
+     * A local position offset. Note, it will be added on top of any
+     * {@link ShapeComponent.shapePosition} you have on a component.
+     *
      * @type {Vec3}
      * @defaultValue Vec3(0, 0, 0)
      */
     shapePosition;
 
     /**
-     * @see {@link ShapeComponent.shapeRotation}
+     * A local rotation offset. Note, it will be added on top of any
+     * {@link ShapeComponent.shapeRotation} you have on a component.
+     *
      * @type {Quat}
      * @defaultValue Quat(0, 0, 0, 1)
      */
@@ -266,5 +277,5 @@ class ShapeSettings {
 
 export {
     QuerySettings, CastSettings, CastRaySettings, CastShapeSettings, CollideShapeSettings,
-    ShapeSettings
+    ShapeSettings, ImmediateSettings
 };

--- a/src/physics/jolt/interfaces/settings.mjs
+++ b/src/physics/jolt/interfaces/settings.mjs
@@ -27,6 +27,15 @@ class QuerySettings {
      * @defaultValue OBJ_LAYER_MOVING (1)
      */
     objFilterLayer;
+
+    /**
+     * Whether to make a query and return the results immediately. Only supported when physics
+     * is running on main thread.
+     *
+     * @type {boolean}
+     * @defaultValue true
+     */
+    immediate;
 }
 
 /**

--- a/src/physics/jolt/manager.mjs
+++ b/src/physics/jolt/manager.mjs
@@ -217,6 +217,16 @@ class JoltManager extends PhysicsManager {
     }
 
     /**
+     * Gets the current gravity vector.
+     *
+     * @type {Vec3}
+     * @defaultValue Vec3(0, -9.81, 0)
+     */
+    get gravity() {
+        return this._gravity;
+    }
+
+    /**
      * @param {object} instance - Jolt backend instance.
      * @hidden
      */
@@ -247,16 +257,6 @@ class JoltManager extends PhysicsManager {
      */
     get backend() {
         return this._backend;
-    }
-
-    /**
-     * Gets the current gravity vector.
-     *
-     * @type {Vec3}
-     * @defaultValue Vec3(0, -9.81, 0)
-     */
-    get gravity() {
-        return this._gravity;
     }
 
     /**
@@ -443,7 +443,7 @@ class JoltManager extends PhysicsManager {
 
         const useImmediate = !this._config.useWebWorker && (opts?.immediate ?? true);
         const cb = useImmediate ? this._immediateBuffer : this._outBuffer;
-        
+
         if (useImmediate) {
             cb.init();
             cb.reset();
@@ -452,7 +452,7 @@ class JoltManager extends PhysicsManager {
         cb.writeOperator(OPERATOR_CLEANER);
         cb.writeCommand(CMD_DESTROY_SHAPE);
         cb.write(index, BUFFER_WRITE_UINT32, false);
-        
+
         this._shapeMap.free(index);
 
         if (useImmediate) {
@@ -530,7 +530,7 @@ class JoltManager extends PhysicsManager {
                 ok = false;
             }
             if (!ok) {
-                return;
+                return null;
             }
         }
 
@@ -635,7 +635,7 @@ class JoltManager extends PhysicsManager {
             }
 
             if (!ok) {
-                return;
+                return null;
             }
         }
 
@@ -735,7 +735,7 @@ class JoltManager extends PhysicsManager {
                 ok = false;
             }
             if (!ok) {
-                return;
+                return null;
             }
         }
 
@@ -843,7 +843,7 @@ class JoltManager extends PhysicsManager {
                 ok = false;
             }
             if (!ok) {
-                return;
+                return null;
             }
         }
 

--- a/src/physics/manager.mjs
+++ b/src/physics/manager.mjs
@@ -33,37 +33,6 @@ class PhysicsManager {
     }
 
     /**
-     * @param {import('./jolt/back/backend.mjs').JoltBackend} instance - Jolt backend instance.
-     */
-    set backend(instance) {
-        this._backend = instance;
-    }
-
-    /**
-     * Gets the Jolt Backend instance. This is useful, when components are not sufficient and you
-     * wish to access Jolt's API directly.
-     *
-     * Note, this will be `null`, if the backend runs in a Web Worker.
-     *
-     * @example
-     * ```js
-     * const backend = app.physics.backend;
-     * const Jolt = backend.Jolt;
-     * const joltVec = new Jolt.Vec3(0, 0, 0);
-     *
-     * // common Jolt interfaces, which the backend has instantiated
-     * backend.physicsSystem;
-     * backend.bodyInterface;
-     * backend.joltInterface;
-     * ```
-     *
-     * @type {import('./jolt/back/backend.mjs').JoltBackend | null}
-     */
-    get backend() {
-        return this._backend;
-    }
-
-    /**
      * @type {Map<number, import('./jolt/front/body/system.mjs').BodyComponentSystem |
      * import('./jolt/front/char/system.mjs').CharComponentSystem |
      * import('./jolt/front/constraint/system.mjs').ConstraintComponentSystem |

--- a/src/physics/manager.mjs
+++ b/src/physics/manager.mjs
@@ -235,6 +235,7 @@ class PhysicsManager {
         const msg = Object.create(null);
         msg.type = 'destroy';
         this.sendUncompressed(msg);
+        this._stepMessage = null;
         this._backend = null;
 
         this._commandsBuffer.destroy();


### PR DESCRIPTION
Adds support for immediate queries. They are now enabled by default. Updated documentation to reflect it.

```js
const results = app.physics.castShape(shapeIndex, pos, Quat.IDENTITY, dir, null, {
     ignoreSensors: true
});
if (results.length > 0) {
    // do something with the results
}
```

Background:
All commands that we collect during a frame are aggregated into a commands buffer. At the end of the frame we send it to the backend, which then executes them in sequence. This PR now changes the queries (e.g. raycast, shapecast, etc.) are executed. Instead of them going to the commands buffer and getting their results in the callbacks, they are executed immediately on the backend and return the results. Callbacks are also supported, and will be called, if provided, but are now optional.
Obviously, this is only supported, when running physics on the main thread. When using web worker, all queries go the commands buffer as before and results are delivered to callbacks.