### PR TITLE
Add custom ID guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@gamebop/physics",
     "description": "Physics components for PlayCanvas engine",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "main": "dist/physics.min.mjs",
     "author": "Gamebop",
     "license": "MIT",


### PR DESCRIPTION
PR adds a guard to debug build, against cases when user tries to create a body with a custom ID, while there is already an existing body in the physics world with the same ID.