### PR TITLE
Reset outbound command buffer

### DIFF
--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -314,6 +314,7 @@ class JoltBackend {
         }
 
         // Make sure there are no lingering command counters before we start writing new ones.
+        outBuffer.reset();
         outBuffer.init();
 
         let ok = true;


### PR DESCRIPTION
Reset the outbound command buffer, before we write to it, to reset the bytes offset.