### PR TITLE
Fix race condition on virtual characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.5.2",
             "license": "MIT",
             "devDependencies": {
-                "@babel/eslint-parser": "^7.25.9",
+                "@babel/eslint-parser": "^7.27.0",
                 "@eslint/js": "^9.17.0",
                 "@playcanvas/eslint-config": "^2.0.8",
                 "@rollup/plugin-json": "^6.1.0",
@@ -32,7 +32,7 @@
                 "@rollup/rollup-linux-x64-gnu": "^4.29.1"
             },
             "peerDependencies": {
-                "jolt-physics": "^0.34.0",
+                "jolt-physics": "^0.35.0",
                 "playcanvas": "^2.2.1"
             }
         },
@@ -111,9 +111,9 @@
             }
         },
         "node_modules/@babel/eslint-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz",
-            "integrity": "sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.27.0.tgz",
+            "integrity": "sha512-dtnzmSjXfgL/HDgMcmsLSzyGbEosi4DrGWoCNfuI+W4IkVJw6izpTe7LtOdwAXnkDqw5yweboYCTkM2rQizCng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -233,29 +233,29 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+            "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.27.0",
+                "@babel/types": "^7.27.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-            "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+            "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/types": "^7.26.3"
+                "@babel/types": "^7.27.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -265,16 +265,16 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+            "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.26.2",
+                "@babel/parser": "^7.27.0",
+                "@babel/types": "^7.27.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -312,9 +312,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.3",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+            "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -3656,9 +3656,9 @@
             }
         },
         "node_modules/jolt-physics": {
-            "version": "0.34.0",
-            "resolved": "https://registry.npmjs.org/jolt-physics/-/jolt-physics-0.34.0.tgz",
-            "integrity": "sha512-qZKhGL8P7Ug179eYsQQuwji2tmlqnQ1GlNCMWnKBHJhrioYAr0MReWwkLEx9vOiCdV17q7eCgGs2Xq9UddKZPg==",
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/jolt-physics/-/jolt-physics-0.35.0.tgz",
+            "integrity": "sha512-5twnPpP48v1Oi78s7J0iUusOrN14sNPOLFWfiJX29VujQ/8PqucKF0PlG/FhY01+zpOUXLO5+Tyoxa2OUTkPWw==",
             "license": "MIT",
             "peer": true
         },

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
         "dist/*"
     ],
     "peerDependencies": {
-        "jolt-physics": "^0.34.0",
+        "jolt-physics": "^0.35.0",
         "playcanvas": "^2.2.1"
     },
     "devDependencies": {
-        "@babel/eslint-parser": "^7.25.9",
+        "@babel/eslint-parser": "^7.27.0",
         "@eslint/js": "^9.17.0",
         "@playcanvas/eslint-config": "^2.0.8",
         "@rollup/plugin-json": "^6.1.0",

--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -30,7 +30,7 @@ class JoltBackend {
             // Physics Settings
             // https://jrouwe.github.io/JoltPhysics/struct_physics_settings.html
             baumgarte: 0.2,
-            maxSkippedSteps: 3,
+            maxSkippedSteps: 1,
             bodyPairCacheCosMaxDeltaRotationDiv2: 0.9998476951563912,
             bodyPairCacheMaxDeltaPositionSq: Math.sqrt(0.001),
             contactNormalCosMaxDeltaRotation: 0.9961946980917455,


### PR DESCRIPTION
- Fixes a race condition, when the backend was updating the virtual characters front components late, if an update callback was trying to read its properties.
- Updates Jolt to latest (fixes, reduced size)
- Fixes audit warnings