### PR TITLE
Remove update callback

### DIFF
--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -98,7 +98,6 @@ class JoltBackend {
         this._bodyFilter = null;
         this._shapeFilter = null;
         this._bodyList = null;
-        this._updateCallback = null;
         this._idleCallback = null;
         this._groupFilterTables = [];
 
@@ -217,14 +216,6 @@ class JoltBackend {
         return this._bodyList;
     }
 
-    set updateCallback(func) {
-        this._updateCallback = func;
-    }
-
-    get updateCallback() {
-        return this._updateCallback;
-    }
-
     set idleCallback(func) {
         this._idleCallback = func;
     }
@@ -330,12 +321,6 @@ class JoltBackend {
             time -= fixedStep;
         }
         this._time = time;
-
-        if (this._updateCallback && stepsCount) {
-            for (let i = 0; i < stepsCount; i++) {
-                this._updateCallback?.();
-            }
-        }
 
         if (data.inBuffer) {
             outBuffer.buffer = data.inBuffer;
@@ -456,7 +441,6 @@ class JoltBackend {
         this._immediateBuffer?.destroy();
         this._immediateBuffer = null;
 
-        this._updateCallback = null;
         this._idleCallback = null;
 
         this.Jolt = null;

--- a/src/physics/jolt/manager.mjs
+++ b/src/physics/jolt/manager.mjs
@@ -364,44 +364,6 @@ class JoltManager extends PhysicsManager {
     }
 
     /**
-     * Sometimes it is useful to have a callback right before the physics world steps. You can set
-     * such a callback function via this method.
-     *
-     * Your given callback will be called after all commands have been executed and right before
-     * we update virtual characters and step the physics world.
-     *
-     * Note, this feature is disabled, when the backend runs in a web worker.
-     *
-     * @param {function} func - Callback function to execute before stepping the physics world.
-     */
-    addUpdateCallback(func) {
-        // TODO
-        // add support for web worker
-        if (this._config.useWebWorker) {
-            if ($_DEBUG) {
-                Debug.warn('Physics update callback is not supported when web worker is enabled.');
-            }
-            return;
-        }
-
-        this._backend.updateCallback = func;
-    }
-
-    /**
-     * Removes a callback that was set via {@link addUpdateCallback}.
-     */
-    removeUpdateCallback() {
-        if (this._config.useWebWorker) {
-            if ($_DEBUG) {
-                Debug.warn('Physics update callback is not supported when Web Worker is enabled.');
-            }
-            return;
-        }
-
-        this._backend.updateCallback = null;
-    }
-
-    /**
      * Creates a shape in the physics backend. Note, that the shape is not added to the physics
      * world after it is created, so it won't affect the simulation.
      *


### PR DESCRIPTION
Removes the update callback.

It gets desync. A better way is to count timestep time at user land.