### PR TITLE
fix fraction for collide shape

### DIFF
--- a/src/physics/jolt/back/operators/querier.mjs
+++ b/src/physics/jolt/back/operators/querier.mjs
@@ -29,10 +29,8 @@ function writeCollideShapeHit(cb, system, tracker, calculateNormal, hit, Jolt) {
     cb.write(hit.mContactPointOn2, BUFFER_WRITE_JOLTVEC32, false);
     cb.write(hit.mPenetrationAxis, BUFFER_WRITE_JOLTVEC32, false);
     cb.write(hit.mPenetrationDepth, BUFFER_WRITE_FLOAT32, false);
-
     // collide shape query doesn't have fraction
     cb.write(hit.mFraction, BUFFER_WRITE_FLOAT32);
-    
     cb.write(normal, BUFFER_WRITE_JOLTVEC32);
 }
 

--- a/src/physics/jolt/back/operators/querier.mjs
+++ b/src/physics/jolt/back/operators/querier.mjs
@@ -29,7 +29,10 @@ function writeCollideShapeHit(cb, system, tracker, calculateNormal, hit, Jolt) {
     cb.write(hit.mContactPointOn2, BUFFER_WRITE_JOLTVEC32, false);
     cb.write(hit.mPenetrationAxis, BUFFER_WRITE_JOLTVEC32, false);
     cb.write(hit.mPenetrationDepth, BUFFER_WRITE_FLOAT32, false);
-    cb.write(hit.mFraction, BUFFER_WRITE_FLOAT32, false);
+
+    // collide shape query doesn't have fraction
+    cb.write(hit.mFraction, BUFFER_WRITE_FLOAT32);
+    
     cb.write(normal, BUFFER_WRITE_JOLTVEC32);
 }
 

--- a/src/physics/jolt/front/response-handler.mjs
+++ b/src/physics/jolt/front/response-handler.mjs
@@ -404,7 +404,7 @@ class ResponseHandler {
                         fromBuffer(cb),
                         fromBuffer(cb),
                         cb.read(BUFFER_READ_FLOAT32),
-                        cb.read(BUFFER_READ_FLOAT32),
+                        cb.flag ? cb.read(BUFFER_READ_FLOAT32) : 0,
                         cb.flag ? fromBuffer(cb) : null
                     ));
                 } else {


### PR DESCRIPTION
Ignore fraction in collide shape query, as it doesn't have one.