### PR TITLE
Add IB byte offset workaround

### DIFF
--- a/src/physics/jolt/front/shape/component.mjs
+++ b/src/physics/jolt/front/shape/component.mjs
@@ -795,6 +795,11 @@ class ShapeComponent extends Component {
         if (isView) {
             // byteLength = storage.byteLength;
             byteOffset = storage.byteOffset;
+        } else if (storage instanceof ArrayBuffer) {
+            // workaround, since PlayCanvas has a bug, where
+            // it assigns an ArrayBuffer directly as a storage
+            // for generated shapes, like cone.
+            byteOffset = 0;
         } else {
             // byteLength = storage.byteLength / ib.bytesPerIndex;
             byteOffset = storage.buffer.byteOffset;


### PR DESCRIPTION
PlayCanvas engine has a bug, where it assigns an Array Buffer directly as a storage, instead of a typed array view. For example, for a generated cone shape.

This is a workaround until it is fixed.

Related:
https://github.com/playcanvas/engine/issues/5869