### PR TITLE
Ignore kinematic transforms

### DIFF
--- a/src/physics/jolt/back/backend.mjs
+++ b/src/physics/jolt/back/backend.mjs
@@ -13,7 +13,7 @@ import {
     BUFFER_WRITE_JOLTVEC32, BUFFER_WRITE_UINT32, BUFFER_WRITE_UINT8, BUFFER_WRITE_VEC32,
     CMD_REPORT_TRANSFORMS, COMPONENT_SYSTEM_BODY, COMPONENT_SYSTEM_CHAR,
     COMPONENT_SYSTEM_SOFT_BODY, GROUND_STATE_IN_AIR, GROUND_STATE_NOT_SUPPORTED,
-    GROUND_STATE_ON_GROUND, GROUND_STATE_ON_STEEP_GROUND, ISOMETRY_FRONT_TO_BACK,
+    GROUND_STATE_ON_GROUND, GROUND_STATE_ON_STEEP_GROUND, ISOMETRY_DEFAULT, ISOMETRY_FRONT_TO_BACK,
     ISOMETRY_NONE, OBJ_LAYER_MOVING, OBJ_LAYER_NON_MOVING, OPERATOR_CLEANER,
     OPERATOR_CREATOR, OPERATOR_MODIFIER, OPERATOR_QUERIER
 } from '../constants.mjs';
@@ -841,6 +841,11 @@ class JoltBackend {
                 if (Jolt.getPointer(body) === 0 ||
                         body.isometryUpdate === ISOMETRY_FRONT_TO_BACK ||
                         body.isometryUpdate === ISOMETRY_NONE ||
+                        (body.isometryUpdate === ISOMETRY_DEFAULT &&
+                            body.GetMotionType() === Jolt.EMotionType_Kinematic) ||
+
+                        // TODO
+                        // deprecate char paired bodies, use new Jolt API
                         body.isCharPaired) {
                     continue;
                 }


### PR DESCRIPTION
Ignore kinematic transform updates on front-end, when using default isometry update for a body.